### PR TITLE
Global settings

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,6 +25,7 @@ and uses Angular for the window chrome parts of the UI.
   - Never use `@Input` or `@Output` (instead use `input` and `output` signal based functions).
 - Make sure there are no type errors in the code.
 - Components are standalone by default.
+- Do not prefix component selectors with `app-` or any other prefix.
 
 ## C# Features
 - Use new language features where applicable.

--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ You can search via a number of providers from the action dialog:
 - GitHub: `!gh <query>`
 - ChatGPT: `!ai <query>`
 - YouTube: `!y <query>`
+
+## Content Pages
+
+These are the addresses which are handled by the application to provide special functionality.
+
+- `/settings`: Edit global settings for the application.

--- a/src/BrowserHost/ContentServer.cs
+++ b/src/BrowserHost/ContentServer.cs
@@ -7,15 +7,22 @@ using System.Threading.Tasks;
 #endif
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace BrowserHost;
 
 public record ContentPage(string Address, string Title, string Favicon);
 
+public enum ContentPageUrlMode
+{
+    Relative,
+    Absolute
+}
+
 static class ContentServer
 {
-    private const string SettingsFavicon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' fill='none'%3E%3Ccircle cx='16' cy='16' r='8' stroke='%23666' stroke-width='2' fill='white'/%3E%3Cpath d='M16 6V2M16 30v-4M6 16H2M30 16h-4M8.22 8.22l-2.83-2.83M26.61 26.61l-2.83-2.83M8.22 23.78l-2.83 2.83M26.61 5.39l-2.83 2.83' stroke='%23666' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E";
+    private const string SettingsFavicon = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 64 64'><defs><linearGradient id='g' x1='0' y1='0' x2='0' y2='1'><stop offset='0%' stop-color='%23f8fafc'/><stop offset='100%' stop-color='%23e2e8f0'/></linearGradient></defs><circle cx='32' cy='32' r='30' fill='url(%23g)' stroke='%2394a3b8' stroke-width='2'/><g transform='translate(32,32)'><g fill='%23565f7a'><circle r='8' fill='%238ea2b8'/><g stroke='%23565f7a' stroke-width='4' stroke-linecap='round'><line x1='0' y1='-18' x2='0' y2='-26'/><line x1='0' y1='18' x2='0' y2='26'/><line x1='18' y1='0' x2='26' y2='0'/><line x1='-18' y1='0' x2='-26' y2='0'/><line x1='12.7' y1='12.7' x2='18.4' y2='18.4'/><line x1='-12.7' y1='-12.7' x2='-18.4' y2='-18.4'/><line x1='12.7' y1='-12.7' x2='18.4' y2='-18.4'/><line x1='-12.7' y1='12.7' x2='-18.4' y2='18.4'/></g></g></g></svg>";
 
 #if DEBUG
     private const string _host = "http://localhost:4200";
@@ -44,10 +51,20 @@ static class ContentServer
         return url.StartsWith(_host, StringComparison.OrdinalIgnoreCase);
     }
 
+    // Note that this information is duplicated in app.routes.ts
     public static readonly ContentPage[] Pages = [new("/settings", "Settings", SettingsFavicon)];
 
-    public static bool IsContentPage(string url) =>
-        Pages.Select(p => p.Address).Contains(url.Trim(), StringComparer.OrdinalIgnoreCase);
+    public static bool IsContentPage(string url, [NotNullWhen(true)] out ContentPage? contentPage, ContentPageUrlMode urlMode = ContentPageUrlMode.Relative)
+    {
+        var adjustedUrl = urlMode switch
+        {
+            ContentPageUrlMode.Relative => url.Trim(),
+            ContentPageUrlMode.Absolute => "/" + url.Trim().Split('/').Last(),
+            _ => throw new ArgumentOutOfRangeException(nameof(urlMode), urlMode, null)
+        };
+        contentPage = Pages.FirstOrDefault(p => p.Address.Equals(adjustedUrl, StringComparison.OrdinalIgnoreCase));
+        return contentPage != null;
+    }
 
 #if !DEBUG
     private static WebServer CreateWebServer()

--- a/src/BrowserHost/ContentServer.cs
+++ b/src/BrowserHost/ContentServer.cs
@@ -47,6 +47,7 @@ static class ContentServer
         .WithStaticFolder("/action-dialog", chromeAppActionDialog, true, m => m.WithContentCaching())
         .WithStaticFolder("/action-context", tabs, true, m => m.WithContentCaching())
         .WithStaticFolder("/tab-palette", tabs, true, m => m.WithContentCaching())
+        .WithStaticFolder("/settings", tabs, true, m => m.WithContentCaching())
         ;
     }
 #endif

--- a/src/BrowserHost/ContentServer.cs
+++ b/src/BrowserHost/ContentServer.cs
@@ -66,6 +66,10 @@ static class ContentServer
         return contentPage != null;
     }
 
+    public static bool IsSettingsPage(string url) =>
+        IsContentPage(url, out var contentPage, ContentPageUrlMode.Absolute) &&
+        contentPage.Address.Equals("/settings", StringComparison.OrdinalIgnoreCase);
+
 #if !DEBUG
     private static WebServer CreateWebServer()
     {

--- a/src/BrowserHost/ContentServer.cs
+++ b/src/BrowserHost/ContentServer.cs
@@ -6,6 +6,9 @@ using System.IO;
 using System.Threading.Tasks;
 #endif
 
+using System;
+using System.Linq;
+
 namespace BrowserHost;
 
 static class ContentServer
@@ -29,6 +32,20 @@ static class ContentServer
 
     public static string GetUiAddress(string path) =>
         _host + path;
+
+    public static bool IsContentServerUrl(string url)
+    {
+        if (string.IsNullOrEmpty(url))
+            return false;
+        return url.StartsWith(_host, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static readonly string[] Pages = ["/settings"];
+
+    public static bool IsContentPage(string url)
+    {
+        return Pages.Contains(url.Trim(), StringComparer.OrdinalIgnoreCase);
+    }
 
 #if !DEBUG
     private static WebServer CreateWebServer()

--- a/src/BrowserHost/ContentServer.cs
+++ b/src/BrowserHost/ContentServer.cs
@@ -11,8 +11,12 @@ using System.Linq;
 
 namespace BrowserHost;
 
+public record ContentPage(string Address, string Title, string Favicon);
+
 static class ContentServer
 {
+    private const string SettingsFavicon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' fill='none'%3E%3Ccircle cx='16' cy='16' r='8' stroke='%23666' stroke-width='2' fill='white'/%3E%3Cpath d='M16 6V2M16 30v-4M6 16H2M30 16h-4M8.22 8.22l-2.83-2.83M26.61 26.61l-2.83-2.83M8.22 23.78l-2.83 2.83M26.61 5.39l-2.83 2.83' stroke='%23666' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E";
+
 #if DEBUG
     private const string _host = "http://localhost:4200";
 #else
@@ -40,12 +44,10 @@ static class ContentServer
         return url.StartsWith(_host, StringComparison.OrdinalIgnoreCase);
     }
 
-    public static readonly string[] Pages = ["/settings"];
+    public static readonly ContentPage[] Pages = [new("/settings", "Settings", SettingsFavicon)];
 
-    public static bool IsContentPage(string url)
-    {
-        return Pages.Contains(url.Trim(), StringComparer.OrdinalIgnoreCase);
-    }
+    public static bool IsContentPage(string url) =>
+        Pages.Select(p => p.Address).Contains(url.Trim(), StringComparer.OrdinalIgnoreCase);
 
 #if !DEBUG
     private static WebServer CreateWebServer()

--- a/src/BrowserHost/Features/ActionDialog/ActionDialogFeature.cs
+++ b/src/BrowserHost/Features/ActionDialog/ActionDialogFeature.cs
@@ -48,13 +48,6 @@ public class ActionDialogFeature(MainWindow window) : Feature(window)
 
         if (ContentServer.IsContentPage(e.Command, out var page))
         {
-            // Do we handle this as a regular page or not?
-            // We want some changed behavior - namely an alias for the url and title and a dedicated icon
-            // How do we want this to be persisted in workspaces.json and navigationHistory.json?
-            // Do we want the tab to be bookmarkable and pinnable?
-            // Do we want to pre populate the navigation history results with all available pages?
-
-            // For now, we treat it as a regular navigation command.
             var pageUrl = ContentServer.GetUiAddress(page.Address);
             PubSub.Publish(new NavigationStartedEvent(pageUrl, UseCurrentTab: e.Ctrl, SaveInHistory: false));
             return;

--- a/src/BrowserHost/Features/ActionDialog/ActionDialogFeature.cs
+++ b/src/BrowserHost/Features/ActionDialog/ActionDialogFeature.cs
@@ -40,6 +40,26 @@ public class ActionDialogFeature(MainWindow window) : Feature(window)
             return;
         }
 
+        if (ContentServer.IsContentServerUrl(e.Command))
+        {
+            // We don't handle content server URLs
+            return;
+        }
+
+        if (ContentServer.IsContentPage(e.Command))
+        {
+            // Do we handle this as a regular page or not?
+            // We want some changed behavior - namely an alias for the url and title and a dedicated icon
+            // How do we want this to be persisted in workspaces.json and navigationHistory.json?
+            // Do we want the tab to be bookmarkable and pinnable?
+            // Do we want to pre populate the navigation history results with all available pages?
+
+            // For now, we treat it as a regular navigation command.
+            var pageUrl = ContentServer.GetUiAddress(e.Command);
+            PubSub.Publish(new NavigationStartedEvent(pageUrl, UseCurrentTab: e.Ctrl, SaveInHistory: false));
+            return;
+        }
+
         PubSub.Publish(new NavigationStartedEvent(e.Command, UseCurrentTab: e.Ctrl, SaveInHistory: true));
     }
 

--- a/src/BrowserHost/Features/ActionDialog/ActionDialogFeature.cs
+++ b/src/BrowserHost/Features/ActionDialog/ActionDialogFeature.cs
@@ -46,7 +46,7 @@ public class ActionDialogFeature(MainWindow window) : Feature(window)
             return;
         }
 
-        if (ContentServer.IsContentPage(e.Command))
+        if (ContentServer.IsContentPage(e.Command, out var page))
         {
             // Do we handle this as a regular page or not?
             // We want some changed behavior - namely an alias for the url and title and a dedicated icon
@@ -55,7 +55,7 @@ public class ActionDialogFeature(MainWindow window) : Feature(window)
             // Do we want to pre populate the navigation history results with all available pages?
 
             // For now, we treat it as a regular navigation command.
-            var pageUrl = ContentServer.GetUiAddress(e.Command);
+            var pageUrl = ContentServer.GetUiAddress(page.Address);
             PubSub.Publish(new NavigationStartedEvent(pageUrl, UseCurrentTab: e.Ctrl, SaveInHistory: false));
             return;
         }

--- a/src/BrowserHost/Features/ActionDialog/NavigationHistoryStateManager.cs
+++ b/src/BrowserHost/Features/ActionDialog/NavigationHistoryStateManager.cs
@@ -117,10 +117,7 @@ public static class NavigationHistoryStateManager
         if (string.IsNullOrWhiteSpace(searchText))
             return [];
 
-        // Seed suggestions for all the built-in pages
-        ContentServer.Pages.ToList().ForEach(p =>
-            history.Add(p.Address, new(p.Title, p.Favicon))
-        );
+        SeedSuggestionsForBuiltInContentPages(history);
 
         var suggestions = history
             .Where(x => !IsIgnoredAddress(x.Key)) // In case some were saved before the ignore logic was implemented
@@ -133,6 +130,13 @@ public static class NavigationHistoryStateManager
             .ToList();
 
         return suggestions;
+    }
+
+    private static void SeedSuggestionsForBuiltInContentPages(Dictionary<string, NavigationHistoryEntry> history)
+    {
+        ContentServer.Pages.ToList().ForEach(p =>
+            history.Add(p.Address, new(p.Title, p.Favicon))
+        );
     }
 
     private static int GetRelevanceScore(string url, string searchText)

--- a/src/BrowserHost/Features/ActionDialog/NavigationHistoryStateManager.cs
+++ b/src/BrowserHost/Features/ActionDialog/NavigationHistoryStateManager.cs
@@ -60,7 +60,7 @@ public static class NavigationHistoryStateManager
     }
 
     private static bool IsIgnoredAddress(string address) =>
-        string.IsNullOrWhiteSpace(address) || address.StartsWith("file://", StringComparison.OrdinalIgnoreCase);
+        string.IsNullOrWhiteSpace(address) || address.StartsWith("file://", StringComparison.OrdinalIgnoreCase) || ContentServer.IsContentServerUrl(address);
 
     private static string NormalizeAddress(string address)
     {
@@ -101,7 +101,7 @@ public static class NavigationHistoryStateManager
             Debug.WriteLine($"Failed to load navigation history: {e.Message}");
         }
 
-        return new Dictionary<string, NavigationHistoryEntry>();
+        return [];
     }
 
     public static List<NavigationSuggestion> GetSuggestions(string searchText, int maxSuggestions = 5)
@@ -116,6 +116,11 @@ public static class NavigationHistoryStateManager
 
         if (string.IsNullOrWhiteSpace(searchText))
             return [];
+
+        // Seed suggestions for all the built-in pages
+        ContentServer.Pages.ToList().ForEach(p =>
+            history.Add(p, new(p, null)) // TODO: Add a proper title and favicon for built-in pages
+        );
 
         var suggestions = history
             .Where(x => !IsIgnoredAddress(x.Key)) // In case some were saved before the ignore logic was implemented

--- a/src/BrowserHost/Features/ActionDialog/NavigationHistoryStateManager.cs
+++ b/src/BrowserHost/Features/ActionDialog/NavigationHistoryStateManager.cs
@@ -111,7 +111,7 @@ public static class NavigationHistoryStateManager
         lock (_cacheLock)
         {
             EnsureCacheLoaded();
-            history = _cachedHistory;
+            history = _cachedHistory.ToDictionary();
         }
 
         if (string.IsNullOrWhiteSpace(searchText))
@@ -119,7 +119,7 @@ public static class NavigationHistoryStateManager
 
         // Seed suggestions for all the built-in pages
         ContentServer.Pages.ToList().ForEach(p =>
-            history.Add(p, new(p, null)) // TODO: Add a proper title and favicon for built-in pages
+            history.Add(p.Address, new(p.Title, p.Favicon))
         );
 
         var suggestions = history

--- a/src/BrowserHost/Features/DevTool/DevToolFeature.cs
+++ b/src/BrowserHost/Features/DevTool/DevToolFeature.cs
@@ -43,7 +43,6 @@ public class DevToolFeature(MainWindow window) : Feature(window)
         var currentTab = Window.CurrentTab;
         if (currentTab == null) return;
 
-        var browserHost = currentTab.GetBrowserHost();
         ToggleDevTools(currentTab.GetBrowserHost());
     }
 

--- a/src/BrowserHost/Features/Settings/SettingsBrowserApi.cs
+++ b/src/BrowserHost/Features/Settings/SettingsBrowserApi.cs
@@ -1,0 +1,21 @@
+﻿using BrowserHost.CefInfrastructure;
+using BrowserHost.Utilities;
+
+namespace BrowserHost.Features.Settings;
+
+public record SettingsPageLoadingEvent();
+public record SettingsSavedEvent(SettingUiStateDto Settings);
+
+public record SettingUiStateDto(string? UserAgent);
+
+public class SettingsBrowserApi : BrowserApi
+{
+    public void SettingsPageLoading() =>
+        PubSub.Publish(new SettingsPageLoadingEvent());
+
+    public void SaveSettings(dynamic settings)
+    {
+        var dto = new SettingUiStateDto(settings.userAgent);
+        PubSub.Publish(new SettingsSavedEvent(dto));
+    }
+}

--- a/src/BrowserHost/Features/Settings/SettingsFeature.cs
+++ b/src/BrowserHost/Features/Settings/SettingsFeature.cs
@@ -1,0 +1,27 @@
+﻿using BrowserHost.Features.Tabs;
+using BrowserHost.Utilities;
+
+namespace BrowserHost.Features.Settings;
+
+public class SettingsFeature(MainWindow window) : Feature(window)
+{
+    private readonly SettingsBrowserApi _browserApi = new();
+    private SettingsDataV1 _settings = SettingsStateManager.RestoreSettingsFromDisk();
+
+    public override void Configure()
+    {
+        PubSub.Subscribe<TabBrowserCreatedEvent>(e =>
+        {
+            e.TabBrowser.RegisterContentPageApi(_browserApi, "settingsApi");
+        });
+        PubSub.Subscribe<SettingsPageLoadingEvent>(e =>
+        {
+            Window.CurrentTab?.SettingsLoaded(_settings);
+        });
+        PubSub.Subscribe<SettingsSavedEvent>(e =>
+        {
+            var mappedSettings = new SettingsDataV1(e.Settings.UserAgent);
+            _settings = SettingsStateManager.SaveSettings(mappedSettings);
+        });
+    }
+}

--- a/src/BrowserHost/Features/Settings/SettingsFeature.cs
+++ b/src/BrowserHost/Features/Settings/SettingsFeature.cs
@@ -17,7 +17,8 @@ public class SettingsFeature(MainWindow window) : Feature(window)
     {
         PubSub.Subscribe<TabBrowserCreatedEvent>(e =>
         {
-            e.TabBrowser.RegisterContentPageApi(_browserApi, "settingsApi");
+            if (ContentServer.IsSettingsPage(e.TabBrowser.Address))
+                e.TabBrowser.RegisterContentPageApi(_browserApi, "settingsApi");
         });
         PubSub.Subscribe<SettingsPageLoadingEvent>(e =>
         {

--- a/src/BrowserHost/Features/Settings/SettingsFeature.cs
+++ b/src/BrowserHost/Features/Settings/SettingsFeature.cs
@@ -6,7 +6,12 @@ namespace BrowserHost.Features.Settings;
 public class SettingsFeature(MainWindow window) : Feature(window)
 {
     private readonly SettingsBrowserApi _browserApi = new();
-    private SettingsDataV1 _settings = SettingsStateManager.RestoreSettingsFromDisk();
+
+    // These are the settings for the current execution, loaded from disk.
+    // They are only loaded on startup.
+    public static SettingsDataV1 ExecutionSettings { get; } = SettingsStateManager.RestoreSettingsFromDisk();
+
+    private SettingsDataV1 _settings = ExecutionSettings;
 
     public override void Configure()
     {

--- a/src/BrowserHost/Features/Settings/SettingsStateManager.cs
+++ b/src/BrowserHost/Features/Settings/SettingsStateManager.cs
@@ -1,0 +1,81 @@
+﻿using BrowserHost.Utilities;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+
+namespace BrowserHost.Features.Settings;
+
+public record SettingsDataV1(string? UserAgent);
+
+public static class SettingsStateManager
+{
+    private static readonly string _persistedStatePath = AppDataPathManager.GetAppDataFilePath("settings.json");
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new() { WriteIndented = true };
+    private const int _currentVersion = 1;
+    private static SettingsDataV1? _lastSavedSettingsData = null;
+    private static readonly Lock _lock = new();
+
+    public static SettingsDataV1 SaveSettings(SettingsDataV1 settings)
+    {
+        lock (_lock)
+        {
+            if (StateIsEqual(_lastSavedSettingsData, settings))
+            {
+                Debug.WriteLine("Skipping settings state save - no changes detected.");
+                return _lastSavedSettingsData!;
+            }
+
+            try
+            {
+                var versionedData = new PersistentData<SettingsDataV1>
+                {
+                    Version = _currentVersion,
+                    Data = settings
+                };
+                File.WriteAllText(_persistedStatePath, JsonSerializer.Serialize(versionedData, _jsonSerializerOptions));
+                _lastSavedSettingsData = settings;
+            }
+            catch (Exception e) when (!Debugger.IsAttached)
+            {
+                Debug.WriteLine($"Failed to save settings state: {e.Message}");
+            }
+            return _lastSavedSettingsData!;
+        }
+    }
+
+    public static SettingsDataV1 RestoreSettingsFromDisk()
+    {
+        lock (_lock)
+        {
+            try
+            {
+                if (File.Exists(_persistedStatePath))
+                {
+                    var json = File.ReadAllText(_persistedStatePath);
+                    var versionedData = JsonSerializer.Deserialize<PersistentData>(json);
+                    if (versionedData?.Version == _currentVersion)
+                    {
+                        var data = JsonSerializer.Deserialize<PersistentData<SettingsDataV1>>(json)?.Data;
+                        if (data != null)
+                        {
+                            _lastSavedSettingsData = data;
+                        }
+                    }
+                }
+            }
+            catch (Exception e) when (!Debugger.IsAttached)
+            {
+                Debug.WriteLine($"Failed to restore settings state: {e.Message}");
+            }
+            return _lastSavedSettingsData ?? new SettingsDataV1(null);
+        }
+    }
+
+    private static bool StateIsEqual(SettingsDataV1? data1, SettingsDataV1? data2)
+    {
+        if (data1 is null || data2 is null) return false;
+        return data1 == data2;
+    }
+}

--- a/src/BrowserHost/Features/Settings/TabBrowserExtensions.cs
+++ b/src/BrowserHost/Features/Settings/TabBrowserExtensions.cs
@@ -1,0 +1,10 @@
+﻿using BrowserHost.Features.Tabs;
+using BrowserHost.Utilities;
+
+namespace BrowserHost.Features.Settings;
+
+public static class TabBrowserExtensions
+{
+    public static void SettingsLoaded(this TabBrowser browser, SettingsDataV1 settings) =>
+        browser.CallClientApi("settingsLoaded", settings.ToJsonObject());
+}

--- a/src/BrowserHost/Features/TabPalette/TabPaletteFeature.cs
+++ b/src/BrowserHost/Features/TabPalette/TabPaletteFeature.cs
@@ -57,6 +57,9 @@ public class TabPaletteFeature(MainWindow window) : Feature(window)
 
     private void CloseTabPalette()
     {
+        if (!_tabPaletteIsOpen)
+            return;
+
         _tabPaletteIsOpen = false;
         Window.HideTabPalette();
         PubSub.Publish(new StopFindingTextEvent());

--- a/src/BrowserHost/Features/Tabs/TabBrowser.cs
+++ b/src/BrowserHost/Features/Tabs/TabBrowser.cs
@@ -80,4 +80,9 @@ public class TabBrowser : Browser
             base.OnAddressChanged(oldValue, newValue);
         }
     }
+
+    public void RegisterContentPageApi<TApi>(TApi api, string name) where TApi : BrowserApi
+    {
+        RegisterSecondaryApi(api, name);
+    }
 }

--- a/src/BrowserHost/Features/Tabs/TabListBrowserApi.cs
+++ b/src/BrowserHost/Features/Tabs/TabListBrowserApi.cs
@@ -14,6 +14,7 @@ public record TabUrlLoadedSuccessfullyEvent(string TabId);
 public record TabFaviconUrlChangedEvent(string TabId, string? NewFaviconUrl);
 public record TabUiStateDto(string Id, string Title, string? Favicon, bool IsActive, DateTimeOffset Created);
 public record FolderUiStateDto(string Id, string Name, int StartIndex, int EndIndex);
+public record TabBrowserCreatedEvent(TabBrowser TabBrowser);
 
 public class TabListBrowserApi : BrowserApi
 {

--- a/src/BrowserHost/Features/Tabs/TabsFeature.cs
+++ b/src/BrowserHost/Features/Tabs/TabsFeature.cs
@@ -109,6 +109,7 @@ public class TabsFeature(MainWindow window) : Feature(window)
         Window.ActionContext.AddTab(tab, activate: true);
         Window.Dispatcher.Invoke(() => SetCurrentTab(browser));
 
+        PubSub.Publish(new TabBrowserCreatedEvent(browser));
         return browser;
     }
 
@@ -118,6 +119,7 @@ public class TabsFeature(MainWindow window) : Feature(window)
         if (!string.IsNullOrEmpty(title))
             browser.Title = title;
 
+        PubSub.Publish(new TabBrowserCreatedEvent(browser));
         return browser;
     }
 

--- a/src/BrowserHost/MainWindow.xaml.cs
+++ b/src/BrowserHost/MainWindow.xaml.cs
@@ -6,6 +6,7 @@ using BrowserHost.Features.DragDrop;
 using BrowserHost.Features.FileDownloads;
 using BrowserHost.Features.Folders;
 using BrowserHost.Features.PinnedTabs;
+using BrowserHost.Features.Settings;
 using BrowserHost.Features.TabPalette;
 using BrowserHost.Features.Tabs;
 using BrowserHost.Features.Workspaces;
@@ -66,6 +67,7 @@ public partial class MainWindow : Window
             new WorkspacesFeature(this),
             new FoldersFeature(this),
             new TabPaletteFeature(this),
+            new SettingsFeature(this)
         ];
         _features.ForEach(f => f.Configure());
 

--- a/src/BrowserHost/MainWindow.xaml.cs
+++ b/src/BrowserHost/MainWindow.xaml.cs
@@ -180,7 +180,7 @@ public partial class MainWindow : Window
             CurrentTab.AddressChanged -= Tab_AddressChanged;
 
         WebContentBorder.Child = tab;
-        ChromeUI.ChangeAddress(tab?.Address);
+        ChromeUI.ChangeAddress(GetAddressForPresentation(tab?.Address));
 
         if (tab != null)
             tab.AddressChanged += Tab_AddressChanged;
@@ -188,7 +188,15 @@ public partial class MainWindow : Window
 
     private void Tab_AddressChanged(object sender, DependencyPropertyChangedEventArgs e)
     {
-        ChromeUI.ChangeAddress($"{e.NewValue}");
+        ChromeUI.ChangeAddress(GetAddressForPresentation($"{e.NewValue}"));
+    }
+
+    private static string? GetAddressForPresentation(string? address)
+    {
+        if (address != null && ContentServer.IsContentPage(address, out var contentPage, ContentPageUrlMode.Absolute))
+            return contentPage.Address;
+
+        return address;
     }
 
     private static void OnWorkspaceColorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/src/BrowserHost/ProgramPublishSingleFile.cs
+++ b/src/BrowserHost/ProgramPublishSingleFile.cs
@@ -1,4 +1,5 @@
-﻿using CefSharp;
+﻿using BrowserHost.Features.Settings;
+using CefSharp;
 using CefSharp.Wpf;
 using System;
 using System.IO;
@@ -22,11 +23,14 @@ public class ProgramPublishSingleFile
         if (exitCode >= 0)
             return exitCode;
 
+        var appSettings = SettingsFeature.ExecutionSettings;
+
         var settings = new CefSettings()
         {
             //By default CefSharp will use an in-memory cache, you need to specify a Cache Folder to persist data
             CachePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "CefSharp\\Cache"),
-            BrowserSubprocessPath = System.Diagnostics.Process.GetCurrentProcess().MainModule!.FileName
+            BrowserSubprocessPath = System.Diagnostics.Process.GetCurrentProcess().MainModule!.FileName,
+            UserAgent = appSettings.UserAgent ?? "",
         };
 
         //Example of setting a command line argument

--- a/src/chrome-app/src/app/app.config.ts
+++ b/src/chrome-app/src/app/app.config.ts
@@ -4,17 +4,19 @@ import {
   provideBrowserGlobalErrorListeners,
   provideZoneChangeDetection,
 } from '@angular/core';
-import { provideRouter } from '@angular/router';
+import { provideRouter, TitleStrategy } from '@angular/router';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { provideAnimations } from '@angular/platform-browser/animations';
 
 import { routes } from './app.routes';
+import { AppTitleStrategy } from './shared/app-title-strategy';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
+    { provide: TitleStrategy, useClass: AppTitleStrategy },
     importProvidersFrom(DragDropModule),
     provideAnimations(),
   ],

--- a/src/chrome-app/src/app/app.routes.ts
+++ b/src/chrome-app/src/app/app.routes.ts
@@ -20,4 +20,8 @@ export const routes: Routes = [
     path: 'tab-palette',
     loadComponent: () => import('./parts/tab-palette/tab-palette.component'),
   },
+  {
+    path: 'settings',
+    loadComponent: () => import('./content-pages/settings/settings.component'),
+  },
 ];

--- a/src/chrome-app/src/app/app.routes.ts
+++ b/src/chrome-app/src/app/app.routes.ts
@@ -5,23 +5,33 @@ export const routes: Routes = [
     path: '',
     loadComponent: () =>
       import('./parts/window-chrome/window-chrome.component'),
+    title: 'ChromeApp',
   },
   {
     path: 'action-dialog',
     loadComponent: () =>
       import('./parts/action-dialog/action-dialog.component'),
+    title: 'ChromeApp',
   },
   {
     path: 'action-context',
     loadComponent: () =>
       import('./parts/action-context/action-context.component'),
+    title: 'ChromeApp',
   },
   {
     path: 'tab-palette',
     loadComponent: () => import('./parts/tab-palette/tab-palette.component'),
+    title: 'ChromeApp',
   },
   {
     path: 'settings',
     loadComponent: () => import('./content-pages/settings/settings.component'),
+    title: 'Settings',
+    data: {
+      // Neutral gear icon in circle, readable on any background
+      favicon:
+        "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 64 64'><defs><linearGradient id='g' x1='0' y1='0' x2='0' y2='1'><stop offset='0%' stop-color='%23f8fafc'/><stop offset='100%' stop-color='%23e2e8f0'/></linearGradient></defs><circle cx='32' cy='32' r='30' fill='url(%23g)' stroke='%2394a3b8' stroke-width='2'/><g transform='translate(32,32)'><g fill='%23565f7a'><circle r='8' fill='%238ea2b8'/><g stroke='%23565f7a' stroke-width='4' stroke-linecap='round'><line x1='0' y1='-18' x2='0' y2='-26'/><line x1='0' y1='18' x2='0' y2='26'/><line x1='18' y1='0' x2='26' y2='0'/><line x1='-18' y1='0' x2='-26' y2='0'/><line x1='12.7' y1='12.7' x2='18.4' y2='18.4'/><line x1='-12.7' y1='-12.7' x2='-18.4' y2='-18.4'/><line x1='12.7' y1='-12.7' x2='18.4' y2='-18.4'/><line x1='-12.7' y1='12.7' x2='-18.4' y2='18.4'/></g></g></g></svg>",
+    },
   },
 ];

--- a/src/chrome-app/src/app/app.routes.ts
+++ b/src/chrome-app/src/app/app.routes.ts
@@ -26,10 +26,10 @@ export const routes: Routes = [
   },
   {
     path: 'settings',
-    loadComponent: () => import('./content-pages/settings/settings.component'),
+    loadComponent: () =>
+      import('./content-pages/settings/settings-page.component'),
     title: 'Settings',
     data: {
-      // Neutral gear icon in circle, readable on any background
       favicon:
         "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 64 64'><defs><linearGradient id='g' x1='0' y1='0' x2='0' y2='1'><stop offset='0%' stop-color='%23f8fafc'/><stop offset='100%' stop-color='%23e2e8f0'/></linearGradient></defs><circle cx='32' cy='32' r='30' fill='url(%23g)' stroke='%2394a3b8' stroke-width='2'/><g transform='translate(32,32)'><g fill='%23565f7a'><circle r='8' fill='%238ea2b8'/><g stroke='%23565f7a' stroke-width='4' stroke-linecap='round'><line x1='0' y1='-18' x2='0' y2='-26'/><line x1='0' y1='18' x2='0' y2='26'/><line x1='18' y1='0' x2='26' y2='0'/><line x1='-18' y1='0' x2='-26' y2='0'/><line x1='12.7' y1='12.7' x2='18.4' y2='18.4'/><line x1='-12.7' y1='-12.7' x2='-18.4' y2='-18.4'/><line x1='12.7' y1='-12.7' x2='18.4' y2='-18.4'/><line x1='-12.7' y1='12.7' x2='-18.4' y2='18.4'/></g></g></g></svg>",
     },

--- a/src/chrome-app/src/app/content-pages/settings/settings-page.component.ts
+++ b/src/chrome-app/src/app/content-pages/settings/settings-page.component.ts
@@ -11,7 +11,7 @@ import {
 import { settingsSchema } from './settings-schema';
 
 @Component({
-  selector: 'settings',
+  selector: 'settings-page',
   imports: [CommonModule, FormsModule],
   template: `
     <div
@@ -90,7 +90,7 @@ import { settingsSchema } from './settings-schema';
   `,
   styles: ``,
 })
-export default class SettingsComponent implements OnInit {
+export default class SettingsPageComponent implements OnInit {
   schema = settingsSchema;
 
   // Local state: saved and currently edited values.
@@ -187,7 +187,7 @@ export default class SettingsComponent implements OnInit {
   }
 
   private defaultForField(field: SettingField) {
-    if (field.defaultValue !== undefined) return field.defaultValue as any;
+    if (field.defaultValue !== undefined) return field.defaultValue;
     switch (field.type) {
       case 'string':
         return '';
@@ -209,7 +209,7 @@ export default class SettingsComponent implements OnInit {
     ]);
     for (const key of keys) {
       const field = this.schema.find((f) => f.key === key);
-      const value = (plain as any)[key];
+      const value = plain[key];
       if (value === undefined) {
         result[key] = this.defaultForKey(key);
         continue;

--- a/src/chrome-app/src/app/content-pages/settings/settings-page.component.ts
+++ b/src/chrome-app/src/app/content-pages/settings/settings-page.component.ts
@@ -93,7 +93,6 @@ import { settingsSchema } from './settings-schema';
 export default class SettingsPageComponent implements OnInit {
   schema = settingsSchema;
 
-  // Local state: saved and currently edited values.
   private savedValues = signal<SettingsValues>({});
   currentValues = signal<SettingsValues>({});
 
@@ -124,7 +123,6 @@ export default class SettingsPageComponent implements OnInit {
     });
   }
 
-  // UI helpers to coerce values for controls
   asString(v: unknown): string {
     return typeof v === 'string' ? v : '';
   }
@@ -161,10 +159,8 @@ export default class SettingsPageComponent implements OnInit {
   save() {
     const values = this.currentValues();
     const plain = this.toPlain(values);
-    Promise.resolve(this.api.saveSettings(plain)).then(() => {
-      // Consider settings saved successfully; update saved snapshot
-      this.savedValues.set({ ...values });
-    });
+    this.savedValues.set({ ...values });
+    this.api.saveSettings(plain);
   }
 
   reset() {

--- a/src/chrome-app/src/app/content-pages/settings/settings-schema.ts
+++ b/src/chrome-app/src/app/content-pages/settings/settings-schema.ts
@@ -1,0 +1,11 @@
+import { SettingField } from './settingsApi';
+
+export const settingsSchema: SettingField[] = [
+  {
+    key: 'userAgent',
+    type: 'string',
+    name: 'User Agent',
+    description: 'Controls the user agent string sent by the browser.',
+    placeholder: '',
+  },
+];

--- a/src/chrome-app/src/app/content-pages/settings/settings.component.ts
+++ b/src/chrome-app/src/app/content-pages/settings/settings.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'settings',
+  template: `SETTINGS`,
+  styles: ``,
+})
+export default class SettingsComponent {
+  // This component is currently empty, but can be expanded in the future.
+}

--- a/src/chrome-app/src/app/content-pages/settings/settings.component.ts
+++ b/src/chrome-app/src/app/content-pages/settings/settings.component.ts
@@ -1,10 +1,258 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, computed, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { exposeApiToBackend, loadBackendApi } from '../../parts/interfaces/api';
+import {
+  SettingField,
+  SettingsApi,
+  SettingsValues,
+  PlainSettings,
+} from './settingsApi.js';
+import { settingsSchema } from './settings-schema';
 
 @Component({
   selector: 'settings',
-  template: `SETTINGS`,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div
+      class="settings-page w-full h-full text-white font-sans  bg-gray-900/90"
+    >
+      <div
+        class="sticky top-0 z-10 flex items-center justify-between px-6 py-4 bg-gray-900/70 backdrop-blur border-b border-white/10"
+      >
+        <h1 class="text-xl font-semibold">Settings</h1>
+
+        <div class="flex items-center gap-2">
+          <button
+            class="px-3 py-1.5 rounded bg-white/10 hover:bg-white/20 disabled:opacity-50 disabled:cursor-not-allowed"
+            [disabled]="!isDirty()"
+            (click)="save()"
+          >
+            Save
+          </button>
+          <button
+            class="px-3 py-1.5 rounded bg-white/5 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed"
+            [disabled]="!isDirty()"
+            (click)="reset()"
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+
+      <div class="px-6 py-4 flex flex-col gap-4">
+        @for (field of schema; track field.key) {
+        <div class="setting-row">
+          <div
+            class="flex items-start gap-6 p-4 rounded-lg bg-white/5 hover:bg-white/10 transition-colors"
+          >
+            <div class="flex-1 min-w-0">
+              <div class="text-sm font-medium">{{ field.name }}</div>
+              <div class="text-xs text-gray-400 mt-1">
+                {{ field.description }}
+              </div>
+            </div>
+
+            <div class="flex-shrink-0 basis-1/2">
+              @if (field.type === 'string') {
+              <input
+                type="text"
+                class="w-full px-2 py-1.5 rounded bg-gray-800 border border-white/10 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                [ngModel]="asString(getValue(field.key))"
+                (ngModelChange)="onStringChange(field.key, $event)"
+                [placeholder]="field.placeholder ?? ''"
+              />
+              } @else if (field.type === 'integer') {
+              <input
+                type="number"
+                class="w-full px-2 py-1.5 rounded bg-gray-800 border border-white/10 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                [ngModel]="asNumber(getValue(field.key))"
+                (ngModelChange)="onIntegerChange(field.key, $event)"
+                step="1"
+              />
+              } @else if (field.type === 'boolean') {
+              <label class="inline-flex items-center gap-2 select-none w-auto">
+                <input
+                  type="checkbox"
+                  class="w-4 h-4 rounded border-white/10 bg-gray-800"
+                  [ngModel]="asBoolean(getValue(field.key))"
+                  (ngModelChange)="onBooleanChange(field.key, $event)"
+                />
+                <span class="text-sm text-gray-300">Enabled</span>
+              </label>
+              }
+            </div>
+          </div>
+        </div>
+        }
+      </div>
+    </div>
+  `,
   styles: ``,
 })
-export default class SettingsComponent {
-  // This component is currently empty, but can be expanded in the future.
+export default class SettingsComponent implements OnInit {
+  schema = settingsSchema;
+
+  // Local state: saved and currently edited values.
+  private savedValues = signal<SettingsValues>({});
+  currentValues = signal<SettingsValues>({});
+
+  api!: SettingsApi;
+
+  isDirty = computed(() => {
+    const a = this.savedValues();
+    const b = this.currentValues();
+    const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+    for (const k of keys) {
+      if (a[k] !== b[k]) return true;
+    }
+    return false;
+  });
+
+  async ngOnInit() {
+    this.api = await loadBackendApi<SettingsApi>('settingsApi');
+
+    this.api.settingsPageLoading();
+
+    exposeApiToBackend({
+      settingsLoaded: (plain: PlainSettings) => {
+        const values = this.fromPlain(plain);
+        const normalized = this.withSchemaDefaults(values);
+        this.savedValues.set(normalized);
+        this.currentValues.set({ ...normalized });
+      },
+    });
+  }
+
+  // UI helpers to coerce values for controls
+  asString(v: unknown): string {
+    return typeof v === 'string' ? v : '';
+  }
+  asNumber(v: unknown): number | null {
+    return typeof v === 'number' && Number.isInteger(v) ? v : null;
+  }
+  asBoolean(v: unknown): boolean {
+    return typeof v === 'boolean' ? v : false;
+  }
+
+  getValue(key: string) {
+    const curr = this.currentValues();
+    return key in curr ? curr[key] : this.defaultForKey(key);
+  }
+
+  onStringChange(key: string, value: string) {
+    this.setValue(key, value);
+  }
+  onIntegerChange(key: string, value: any) {
+    const n =
+      value === '' || value === null || value === undefined
+        ? null
+        : Number.parseInt(String(value), 10);
+    this.setValue(key, Number.isFinite(n as number) ? (n as number) : null);
+  }
+  onBooleanChange(key: string, value: boolean) {
+    this.setValue(key, !!value);
+  }
+
+  setValue(key: string, value: string | number | boolean | null) {
+    this.currentValues.update((curr) => ({ ...curr, [key]: value }));
+  }
+
+  save() {
+    const values = this.currentValues();
+    const plain = this.toPlain(values);
+    Promise.resolve(this.api.saveSettings(plain)).then(() => {
+      // Consider settings saved successfully; update saved snapshot
+      this.savedValues.set({ ...values });
+    });
+  }
+
+  reset() {
+    this.currentValues.set({ ...this.savedValues() });
+  }
+
+  private withSchemaDefaults(values: SettingsValues): SettingsValues {
+    const result: SettingsValues = { ...values };
+    for (const f of this.schema) {
+      if (!(f.key in result)) {
+        result[f.key] = this.defaultForField(f);
+      }
+    }
+    return result;
+  }
+
+  private defaultForKey(key: string) {
+    const f = this.schema.find((s) => s.key === key);
+    return f ? this.defaultForField(f) : null;
+  }
+
+  private defaultForField(field: SettingField) {
+    if (field.defaultValue !== undefined) return field.defaultValue as any;
+    switch (field.type) {
+      case 'string':
+        return '';
+      case 'boolean':
+        return false;
+      case 'integer':
+        return 0;
+      default:
+        return null;
+    }
+  }
+
+  // Convert from a PlainSettings object (only string|number|boolean) to SettingsValues
+  private fromPlain(plain: PlainSettings): SettingsValues {
+    const result: SettingsValues = {};
+    const keys = new Set([
+      ...this.schema.map((f) => f.key),
+      ...Object.keys(plain ?? {}),
+    ]);
+    for (const key of keys) {
+      const field = this.schema.find((f) => f.key === key);
+      const value = (plain as any)[key];
+      if (value === undefined) {
+        result[key] = this.defaultForKey(key);
+        continue;
+      }
+      if (field?.type === 'integer') {
+        // Only keep integers; otherwise null
+        const n = Number(value);
+        result[key] = Number.isInteger(n) ? n : null;
+      } else if (field?.type === 'boolean') {
+        result[key] = Boolean(value);
+      } else if (field?.type === 'string') {
+        // Preserve nulls rather than turning them into the string "null"
+        result[key] = value === null ? null : String(value);
+      } else {
+        // If schema unknown, attempt best-effort mapping
+        if (typeof value === 'string' || typeof value === 'boolean') {
+          result[key] = value;
+        } else if (typeof value === 'number' && Number.isFinite(value)) {
+          result[key] = value;
+        } else {
+          result[key] = null;
+        }
+      }
+    }
+    return result;
+  }
+
+  // Convert SettingsValues back to PlainSettings, dropping nulls
+  private toPlain(values: SettingsValues): PlainSettings {
+    const result: PlainSettings = {};
+    for (const f of this.schema) {
+      const v = values[f.key];
+      if (v === null || v === undefined) continue;
+      if (f.type === 'integer') {
+        // ensure integer
+        const n = Number(v);
+        if (Number.isInteger(n)) result[f.key] = n;
+      } else if (f.type === 'boolean') {
+        result[f.key] = Boolean(v);
+      } else if (f.type === 'string') {
+        result[f.key] = String(v);
+      }
+    }
+    return result;
+  }
 }

--- a/src/chrome-app/src/app/content-pages/settings/settingsApi.ts
+++ b/src/chrome-app/src/app/content-pages/settings/settingsApi.ts
@@ -7,9 +7,9 @@ export type PlainSettings = Record<string, string | number | boolean>;
 export type SettingType = 'string' | 'boolean' | 'integer';
 
 export interface SettingFieldBase {
-  key: string; // dot-separated key like 'editor.fontSize'
-  name: string; // display name
-  description: string; // help text
+  key: string;
+  name: string;
+  description: string;
   defaultValue?: SettingPrimitive;
 }
 

--- a/src/chrome-app/src/app/content-pages/settings/settingsApi.ts
+++ b/src/chrome-app/src/app/content-pages/settings/settingsApi.ts
@@ -1,0 +1,34 @@
+export type SettingPrimitive = string | number | boolean | null;
+
+export type SettingsValues = Record<string, SettingPrimitive>;
+
+export type PlainSettings = Record<string, string | number | boolean>;
+
+export type SettingType = 'string' | 'boolean' | 'integer';
+
+export interface SettingFieldBase {
+  key: string; // dot-separated key like 'editor.fontSize'
+  name: string; // display name
+  description: string; // help text
+  defaultValue?: SettingPrimitive;
+}
+
+export interface StringField extends SettingFieldBase {
+  type: 'string';
+  placeholder?: string;
+}
+
+export interface BooleanField extends SettingFieldBase {
+  type: 'boolean';
+}
+
+export interface IntegerField extends SettingFieldBase {
+  type: 'integer';
+}
+
+export type SettingField = StringField | BooleanField | IntegerField;
+
+export interface SettingsApi {
+  settingsPageLoading: () => void;
+  saveSettings: (values: PlainSettings) => void;
+}

--- a/src/chrome-app/src/app/shared/app-title-strategy.ts
+++ b/src/chrome-app/src/app/shared/app-title-strategy.ts
@@ -1,0 +1,55 @@
+import { DOCUMENT } from '@angular/common';
+import { Inject, Injectable } from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot,
+  TitleStrategy,
+} from '@angular/router';
+
+@Injectable()
+export class AppTitleStrategy extends TitleStrategy {
+  constructor(@Inject(DOCUMENT) private readonly doc: Document) {
+    super();
+  }
+
+  override updateTitle(snapshot: RouterStateSnapshot): void {
+    const title = this.buildTitle(snapshot);
+    if (title !== undefined) {
+      this.doc.title = title;
+    }
+
+    const primary = this.getPrimary(snapshot.root);
+    const favicon = (primary?.data as any)?.['favicon'] as string | undefined;
+    if (favicon) {
+      this.setFavicon(favicon);
+    }
+  }
+
+  private getPrimary(
+    route: ActivatedRouteSnapshot
+  ): ActivatedRouteSnapshot | null {
+    let current: ActivatedRouteSnapshot | null = route;
+    while (current) {
+      if (current.firstChild) {
+        current = current.firstChild;
+      } else {
+        break;
+      }
+    }
+    return current;
+  }
+
+  private setFavicon(href: string): void {
+    const head = this.doc.head || this.doc.getElementsByTagName('head')[0];
+    let link = head.querySelector(
+      "link[rel*='icon']"
+    ) as HTMLLinkElement | null;
+    if (!link) {
+      link = this.doc.createElement('link');
+      link.rel = 'icon';
+      link.type = 'image/svg+xml';
+      head.appendChild(link);
+    }
+    link.href = href;
+  }
+}

--- a/src/chrome-app/src/app/shared/app-title-strategy.ts
+++ b/src/chrome-app/src/app/shared/app-title-strategy.ts
@@ -19,7 +19,7 @@ export class AppTitleStrategy extends TitleStrategy {
     }
 
     const primary = this.getPrimary(snapshot.root);
-    const favicon = (primary?.data as any)?.['favicon'] as string | undefined;
+    const favicon = primary?.data['favicon'] as string | undefined;
     if (favicon) {
       this.setFavicon(favicon);
     }


### PR DESCRIPTION
This PR adds a general approach for viewing certain frontend routes as named content pages by navigating to them by name. The first such page is a settings page for the application where you can override the user agent which the application sends with all requests.