### PR TITLE
Added support for running websites requiring SSO support via a fallback WebView2 browser

### DIFF
--- a/src/BrowserHost/BrowserHost.csproj
+++ b/src/BrowserHost/BrowserHost.csproj
@@ -69,6 +69,7 @@
   <ItemGroup>
     <PackageReference Include="CefSharp.Wpf.NetCore" Version="139.0.280" />
     <PackageReference Include="EmbedIO" Version="3.5.2" />
+	<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3405.78" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
     <PackageReference Include="Velopack" Version="0.0.1298" />
   </ItemGroup>

--- a/src/BrowserHost/Features/ActionContext/Tabs/TabListBrowserApi.cs
+++ b/src/BrowserHost/Features/ActionContext/Tabs/TabListBrowserApi.cs
@@ -1,4 +1,5 @@
 ﻿using BrowserHost.CefInfrastructure;
+using BrowserHost.Tab;
 using BrowserHost.Utilities;
 using System;
 using System.Collections.Generic;

--- a/src/BrowserHost/Features/ActionContext/Tabs/TabsFeature.cs
+++ b/src/BrowserHost/Features/ActionContext/Tabs/TabsFeature.cs
@@ -1,7 +1,6 @@
 using BrowserHost.Features.ActionContext.PinnedTabs;
 using BrowserHost.Features.ActionContext.Workspaces;
 using BrowserHost.Features.ActionDialog;
-using BrowserHost.Features.Settings;
 using BrowserHost.Tab;
 using BrowserHost.Utilities;
 using System;
@@ -15,7 +14,6 @@ public class TabsFeature(MainWindow window) : Feature(window)
 {
     private readonly List<TabBrowser> _tabBrowsers = [];
     private readonly HashSet<string> _loadedWorkspaceIds = [];
-    private SettingsDataV1? _applicationSettings;
 
     public override void Configure()
     {
@@ -65,7 +63,6 @@ public class TabsFeature(MainWindow window) : Feature(window)
             var activeTabBrowser = activeTabId != null ? GetTabBrowserById(activeTabId) : null;
             SetCurrentTab(activeTabBrowser);
         });
-        PubSub.Subscribe<ApplicationSettingsChangedEvent>(e => _applicationSettings = e.Settings);
     }
 
     private void SetCurrentTab(TabBrowser? tab)
@@ -106,10 +103,7 @@ public class TabsFeature(MainWindow window) : Feature(window)
 
     private TabBrowser AddNewTab(string address, bool saveInHistory)
     {
-        if (_applicationSettings == null)
-            throw new InvalidOperationException("Cannot find application settings");
-
-        var browser = new TabBrowser($"{Guid.NewGuid()}", address, Window.ActionContext, setManualAddress: saveInHistory, favicon: null, _applicationSettings);
+        var browser = new TabBrowser($"{Guid.NewGuid()}", address, Window.ActionContext, setManualAddress: saveInHistory, favicon: null);
         _tabBrowsers.Add(browser);
 
         var tab = new TabDto(browser.Id, browser.Title, null, DateTimeOffset.UtcNow);
@@ -122,10 +116,7 @@ public class TabsFeature(MainWindow window) : Feature(window)
 
     private TabBrowser AddExistingTab(string id, string address, string? title, string? favicon)
     {
-        if (_applicationSettings == null)
-            throw new InvalidOperationException("Cannot find application settings");
-
-        var browser = new TabBrowser(id, address, Window.ActionContext, setManualAddress: false, favicon, _applicationSettings);
+        var browser = new TabBrowser(id, address, Window.ActionContext, setManualAddress: false, favicon);
         if (!string.IsNullOrEmpty(title))
             browser.Title = title;
 

--- a/src/BrowserHost/Features/ActionContext/Tabs/TabsFeature.cs
+++ b/src/BrowserHost/Features/ActionContext/Tabs/TabsFeature.cs
@@ -1,6 +1,7 @@
 using BrowserHost.Features.ActionContext.PinnedTabs;
 using BrowserHost.Features.ActionContext.Workspaces;
 using BrowserHost.Features.ActionDialog;
+using BrowserHost.Tab;
 using BrowserHost.Utilities;
 using System;
 using System.Collections.Generic;

--- a/src/BrowserHost/Features/ActionDialog/ActionDialogBrowserApi.cs
+++ b/src/BrowserHost/Features/ActionDialog/ActionDialogBrowserApi.cs
@@ -3,6 +3,7 @@ using BrowserHost.Utilities;
 
 namespace BrowserHost.Features.ActionDialog;
 
+public record ActionDialogShownEvent();
 public record ActionDialogDismissedEvent();
 public record CommandExecutedEvent(string Command, bool Ctrl);
 public record ActionDialogValueChangedEvent(string Value);

--- a/src/BrowserHost/Features/ActionDialog/ActionDialogFeature.cs
+++ b/src/BrowserHost/Features/ActionDialog/ActionDialogFeature.cs
@@ -132,6 +132,7 @@ public class ActionDialogFeature(MainWindow window) : Feature(window)
         Window.ActionDialog.Visibility = Visibility.Visible;
         Window.ActionDialog.Focus();
         Window.ActionDialog.CallClientApi("showDialog");
+        PubSub.Publish(new ActionDialogShownEvent());
 
         if (Window.ActionDialog.RenderTransform is not ScaleTransform)
         {

--- a/src/BrowserHost/Features/CustomWindowChrome/CustomWindowChromeBrowserApi.cs
+++ b/src/BrowserHost/Features/CustomWindowChrome/CustomWindowChromeBrowserApi.cs
@@ -1,6 +1,5 @@
 ﻿using BrowserHost.CefInfrastructure;
 using BrowserHost.Utilities;
-using CefSharp;
 
 namespace BrowserHost.Features.CustomWindowChrome;
 
@@ -15,13 +14,13 @@ public class CustomWindowChromeBrowserApi : BrowserApi
         MainWindow.Instance.Dispatcher.Invoke(() => MainWindow.Instance.CurrentTab?.CanGoForward ?? false);
 
     public void Forward() =>
-        MainWindow.Instance.CurrentTab.Forward();
+        MainWindow.Instance.CurrentTab?.Forward();
 
     public bool CanGoBack() =>
         MainWindow.Instance.Dispatcher.Invoke(() => MainWindow.Instance.CurrentTab?.CanGoBack ?? false);
 
     public void Back() =>
-        MainWindow.Instance.CurrentTab.Back();
+        MainWindow.Instance.CurrentTab?.Back();
 
     public void Reload() =>
         MainWindow.Instance.CurrentTab?.Reload();

--- a/src/BrowserHost/Features/DevTool/DevToolFeature.cs
+++ b/src/BrowserHost/Features/DevTool/DevToolFeature.cs
@@ -11,8 +11,8 @@ public class DevToolFeature(MainWindow window) : Feature(window)
 {
     public override void Configure()
     {
-        PubSub.Subscribe<TabClosedEvent>(e => CloseDevTools(e.Tab));
-        PubSub.Subscribe<TabActivatedEvent>(e => CloseDevTools(e.PreviousTab));
+        PubSub.Subscribe<TabClosedEvent>(e => e.Tab.CloseDevTools());
+        PubSub.Subscribe<TabActivatedEvent>(e => e.PreviousTab?.CloseDevTools());
     }
 
     public override bool HandleOnPreviewKeyDown(KeyEventArgs e)
@@ -44,7 +44,7 @@ public class DevToolFeature(MainWindow window) : Feature(window)
         var currentTab = Window.CurrentTab;
         if (currentTab == null) return;
 
-        ToggleDevTools(currentTab.GetBrowserHost());
+        ToggleDevTools(currentTab);
     }
 
     private void ToggleActionContextDevTools()
@@ -68,10 +68,14 @@ public class DevToolFeature(MainWindow window) : Feature(window)
         }
     }
 
-    private static void CloseDevTools(TabBrowser? tab)
+    private static void ToggleDevTools(TabBrowser? browser)
     {
-        if (tab == null) return;
-
-        tab.GetBrowserHost()?.CloseDevTools();
+        if (browser != null)
+        {
+            if (browser.HasDevTools)
+                browser.CloseDevTools();
+            else
+                browser.ShowDevTools();
+        }
     }
 }

--- a/src/BrowserHost/Features/DevTool/DevToolFeature.cs
+++ b/src/BrowserHost/Features/DevTool/DevToolFeature.cs
@@ -1,4 +1,5 @@
 using BrowserHost.Features.ActionContext.Tabs;
+using BrowserHost.Tab;
 using BrowserHost.Utilities;
 using CefSharp;
 using System.Diagnostics;

--- a/src/BrowserHost/Features/Settings/SettingsBrowserApi.cs
+++ b/src/BrowserHost/Features/Settings/SettingsBrowserApi.cs
@@ -1,21 +1,28 @@
 ﻿using BrowserHost.CefInfrastructure;
 using BrowserHost.Utilities;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace BrowserHost.Features.Settings;
 
 public record SettingsPageLoadingEvent();
 public record SettingsSavedEvent(SettingUiStateDto Settings);
 
-public record SettingUiStateDto(string? UserAgent);
+public record SettingUiStateDto(string? UserAgent, string[] SsoEnabledDomains);
 
 public class SettingsBrowserApi : BrowserApi
 {
     public void SettingsPageLoading() =>
         PubSub.Publish(new SettingsPageLoadingEvent());
 
-    public void SaveSettings(dynamic settings)
+    public void SaveSettings(IDictionary<string, object?> settings)
     {
-        var dto = new SettingUiStateDto(settings.userAgent);
+        var userAgent = settings.TryGetValue("userAgent", out var o) && o is string ua ? ua : null;
+        var ssoEnabledDomains = settings.TryGetValue("ssoEnabledDomains", out var o2) && o2 is IEnumerable<object> list
+            ? list.Cast<string>().ToArray()
+            : [];
+
+        var dto = new SettingUiStateDto(userAgent, ssoEnabledDomains);
         PubSub.Publish(new SettingsSavedEvent(dto));
     }
 }

--- a/src/BrowserHost/Features/Settings/SettingsBrowserApi.cs
+++ b/src/BrowserHost/Features/Settings/SettingsBrowserApi.cs
@@ -7,6 +7,7 @@ namespace BrowserHost.Features.Settings;
 
 public record SettingsPageLoadingEvent();
 public record SettingsSavedEvent(SettingUiStateDto Settings);
+public record ApplicationSettingsChangedEvent(SettingsDataV1 Settings);
 
 public record SettingUiStateDto(string? UserAgent, string[] SsoEnabledDomains);
 

--- a/src/BrowserHost/Features/Settings/SettingsBrowserApi.cs
+++ b/src/BrowserHost/Features/Settings/SettingsBrowserApi.cs
@@ -1,5 +1,6 @@
 ﻿using BrowserHost.CefInfrastructure;
 using BrowserHost.Utilities;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -19,7 +20,12 @@ public class SettingsBrowserApi : BrowserApi
     {
         var userAgent = settings.TryGetValue("userAgent", out var o) && o is string ua ? ua : null;
         var ssoEnabledDomains = settings.TryGetValue("ssoEnabledDomains", out var o2) && o2 is IEnumerable<object> list
-            ? list.Cast<string>().ToArray()
+            ? list
+                .OfType<string>()
+                .Select(s => s.Trim())
+                .Where(s => s.Length > 0)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray()
             : [];
 
         var dto = new SettingUiStateDto(userAgent, ssoEnabledDomains);

--- a/src/BrowserHost/Features/Settings/SettingsBrowserApi.cs
+++ b/src/BrowserHost/Features/Settings/SettingsBrowserApi.cs
@@ -7,7 +7,6 @@ namespace BrowserHost.Features.Settings;
 
 public record SettingsPageLoadingEvent();
 public record SettingsSavedEvent(SettingUiStateDto Settings);
-public record ApplicationSettingsChangedEvent(SettingsDataV1 Settings);
 
 public record SettingUiStateDto(string? UserAgent, string[] SsoEnabledDomains);
 

--- a/src/BrowserHost/Features/Settings/SettingsFeature.cs
+++ b/src/BrowserHost/Features/Settings/SettingsFeature.cs
@@ -28,12 +28,6 @@ public class SettingsFeature(MainWindow window) : Feature(window)
         {
             var mappedSettings = new SettingsDataV1(e.Settings.UserAgent, e.Settings.SsoEnabledDomains);
             _settings = SettingsStateManager.SaveSettings(mappedSettings);
-            PubSub.Publish(new ApplicationSettingsChangedEvent(_settings));
         });
-    }
-
-    public override void Start()
-    {
-        PubSub.Publish(new ApplicationSettingsChangedEvent(_settings));
     }
 }

--- a/src/BrowserHost/Features/Settings/SettingsFeature.cs
+++ b/src/BrowserHost/Features/Settings/SettingsFeature.cs
@@ -22,11 +22,11 @@ public class SettingsFeature(MainWindow window) : Feature(window)
         });
         PubSub.Subscribe<SettingsPageLoadingEvent>(e =>
         {
-            Window.CurrentTab?.SettingsLoaded(_settings);
+            Window.CurrentTab?.SettingsLoaded(new SettingUiStateDto(_settings.UserAgent, _settings.SsoEnabledDomains ?? []));
         });
         PubSub.Subscribe<SettingsSavedEvent>(e =>
         {
-            var mappedSettings = new SettingsDataV1(e.Settings.UserAgent);
+            var mappedSettings = new SettingsDataV1(e.Settings.UserAgent, e.Settings.SsoEnabledDomains);
             _settings = SettingsStateManager.SaveSettings(mappedSettings);
         });
     }

--- a/src/BrowserHost/Features/Settings/SettingsFeature.cs
+++ b/src/BrowserHost/Features/Settings/SettingsFeature.cs
@@ -28,6 +28,12 @@ public class SettingsFeature(MainWindow window) : Feature(window)
         {
             var mappedSettings = new SettingsDataV1(e.Settings.UserAgent, e.Settings.SsoEnabledDomains);
             _settings = SettingsStateManager.SaveSettings(mappedSettings);
+            PubSub.Publish(new ApplicationSettingsChangedEvent(_settings));
         });
+    }
+
+    public override void Start()
+    {
+        PubSub.Publish(new ApplicationSettingsChangedEvent(_settings));
     }
 }

--- a/src/BrowserHost/Features/Settings/SettingsStateManager.cs
+++ b/src/BrowserHost/Features/Settings/SettingsStateManager.cs
@@ -7,7 +7,7 @@ using System.Threading;
 
 namespace BrowserHost.Features.Settings;
 
-public record SettingsDataV1(string? UserAgent);
+public record SettingsDataV1(string? UserAgent, string[]? SsoEnabledDomains);
 
 public static class SettingsStateManager
 {
@@ -69,7 +69,7 @@ public static class SettingsStateManager
             {
                 Debug.WriteLine($"Failed to restore settings state: {e.Message}");
             }
-            return _lastSavedSettingsData ?? new SettingsDataV1(null);
+            return _lastSavedSettingsData ?? new SettingsDataV1(null, []);
         }
     }
 

--- a/src/BrowserHost/Features/Settings/SettingsStateManager.cs
+++ b/src/BrowserHost/Features/Settings/SettingsStateManager.cs
@@ -73,9 +73,14 @@ public static class SettingsStateManager
         }
     }
 
-    private static bool StateIsEqual(SettingsDataV1? data1, SettingsDataV1? data2)
+    private static bool StateIsEqual(SettingsDataV1? a, SettingsDataV1 b)
     {
-        if (data1 is null || data2 is null) return false;
-        return data1 == data2;
+        if (a is null) return false;
+        if (a.UserAgent != b.UserAgent)
+            return false;
+
+        return DataComparisons.AreArraysEqual(a.SsoEnabledDomains, b.SsoEnabledDomains);
     }
+
+
 }

--- a/src/BrowserHost/Features/Settings/TabBrowserExtensions.cs
+++ b/src/BrowserHost/Features/Settings/TabBrowserExtensions.cs
@@ -1,4 +1,4 @@
-﻿using BrowserHost.Features.ActionContext.Tabs;
+﻿using BrowserHost.Tab;
 using BrowserHost.Utilities;
 
 namespace BrowserHost.Features.Settings;

--- a/src/BrowserHost/Features/Settings/TabBrowserExtensions.cs
+++ b/src/BrowserHost/Features/Settings/TabBrowserExtensions.cs
@@ -5,6 +5,6 @@ namespace BrowserHost.Features.Settings;
 
 public static class TabBrowserExtensions
 {
-    public static void SettingsLoaded(this TabBrowser browser, SettingsDataV1 settings) =>
+    public static void SettingsLoaded(this TabBrowser browser, SettingUiStateDto settings) =>
         browser.CallClientApi("settingsLoaded", settings.ToJsonObject());
 }

--- a/src/BrowserHost/Features/TabPalette/FindText/FindTextFeature.cs
+++ b/src/BrowserHost/Features/TabPalette/FindText/FindTextFeature.cs
@@ -1,6 +1,5 @@
 ﻿using BrowserHost.Features.ActionContext.Tabs;
 using BrowserHost.Utilities;
-using CefSharp;
 using System.Windows.Input;
 
 namespace BrowserHost.Features.TabPalette.FindText;
@@ -45,23 +44,23 @@ public class FindTextFeature(MainWindow window) : Feature(window)
 
     private void StartFinding(string term)
     {
-        Window.CurrentTab?.GetBrowser().Find(term, true, false, findNext: true);
+        Window.CurrentTab?.Find(term, true, false, findNext: true);
         _findingTextTerm = term;
     }
 
     private void FindNext(string term)
     {
-        Window.CurrentTab?.GetBrowser().Find(term, forward: true, false, findNext: true);
+        Window.CurrentTab?.Find(term, forward: true, false, findNext: true);
     }
 
     private void FindPrevious(string term)
     {
-        Window.CurrentTab?.GetBrowser().Find(term, forward: false, false, findNext: true);
+        Window.CurrentTab?.Find(term, forward: false, false, findNext: true);
     }
 
     private void StopFinding()
     {
-        Window.CurrentTab?.GetBrowser().StopFinding(true);
+        Window.CurrentTab?.StopFinding(true);
         Window.TabPaletteBrowserControl.FindStatusChanged(null);
         _findingTextTerm = null;
     }

--- a/src/BrowserHost/Features/TabPalette/FindText/FindTextFeature.cs
+++ b/src/BrowserHost/Features/TabPalette/FindText/FindTextFeature.cs
@@ -44,18 +44,18 @@ public class FindTextFeature(MainWindow window) : Feature(window)
 
     private void StartFinding(string term)
     {
-        Window.CurrentTab?.Find(term, true, false, findNext: true);
+        Window.CurrentTab?.Find(term, forward: true, matchCase: false, findNext: true);
         _findingTextTerm = term;
     }
 
     private void FindNext(string term)
     {
-        Window.CurrentTab?.Find(term, forward: true, false, findNext: true);
+        Window.CurrentTab?.Find(term, forward: true, matchCase: false, findNext: true);
     }
 
     private void FindPrevious(string term)
     {
-        Window.CurrentTab?.Find(term, forward: false, false, findNext: true);
+        Window.CurrentTab?.Find(term, forward: false, matchCase: false, findNext: true);
     }
 
     private void StopFinding()

--- a/src/BrowserHost/Features/Zoom/ZoomFeature.cs
+++ b/src/BrowserHost/Features/Zoom/ZoomFeature.cs
@@ -1,5 +1,4 @@
-﻿using CefSharp;
-using System.Windows.Input;
+﻿using System.Windows.Input;
 
 namespace BrowserHost.Features.Zoom;
 
@@ -32,7 +31,7 @@ public class ZoomFeature(MainWindow window) : Feature(window)
         {
             if (Window.CurrentTab is not null)
             {
-                Window.CurrentTab.SetZoomLevel(0);
+                Window.CurrentTab.ResetZoomLevel();
                 return true;
             }
 

--- a/src/BrowserHost/MainWindow.xaml.cs
+++ b/src/BrowserHost/MainWindow.xaml.cs
@@ -56,6 +56,7 @@ public partial class MainWindow : Window
 
         _features =
         [
+            new SettingsFeature(this),
             new CustomWindowChromeFeature(this),
             new ActionDialogFeature(this),
             new TabsFeature(this),
@@ -69,7 +70,6 @@ public partial class MainWindow : Window
             new TabPaletteFeature(this),
             new FindTextFeature(this),
             new TabCustomizationFeature(this),
-            new SettingsFeature(this)
         ];
         _features.ForEach(f => f.Configure());
 

--- a/src/BrowserHost/MainWindow.xaml.cs
+++ b/src/BrowserHost/MainWindow.xaml.cs
@@ -124,6 +124,12 @@ public partial class MainWindow : Window
     {
         base.OnPreviewKeyDown(e);
 
+        ProcessKeyboardEvent(e);
+    }
+
+    public void ProcessKeyboardEvent(KeyEventArgs e)
+    {
+        if (e.Handled) return; // Already handled
         foreach (var feature in _features)
         {
             if (feature.HandleOnPreviewKeyDown(e))
@@ -132,12 +138,11 @@ public partial class MainWindow : Window
                 return;
             }
         }
-
-        // Too small to be handled by features, handle here
-        if (e.Key == Key.F5)
+        if (!e.Handled && e.Key == Key.F5)
         {
             var ignoreCache = Keyboard.Modifiers == ModifierKeys.Control;
             CurrentTab?.Reload(ignoreCache);
+            e.Handled = true;
         }
     }
 

--- a/src/BrowserHost/MainWindow.xaml.cs
+++ b/src/BrowserHost/MainWindow.xaml.cs
@@ -15,7 +15,6 @@ using BrowserHost.Features.TabPalette.TabCustomization;
 using BrowserHost.Features.Zoom;
 using BrowserHost.Tab;
 using BrowserHost.XamlUtilities;
-using CefSharp;
 using CefSharp.Wpf;
 using System;
 using System.Collections.Generic;
@@ -138,7 +137,7 @@ public partial class MainWindow : Window
         if (e.Key == Key.F5)
         {
             var ignoreCache = Keyboard.Modifiers == ModifierKeys.Control;
-            CurrentTab.Reload(ignoreCache);
+            CurrentTab?.Reload(ignoreCache);
         }
     }
 

--- a/src/BrowserHost/MainWindow.xaml.cs
+++ b/src/BrowserHost/MainWindow.xaml.cs
@@ -13,6 +13,7 @@ using BrowserHost.Features.TabPalette;
 using BrowserHost.Features.TabPalette.FindText;
 using BrowserHost.Features.TabPalette.TabCustomization;
 using BrowserHost.Features.Zoom;
+using BrowserHost.Tab;
 using BrowserHost.XamlUtilities;
 using CefSharp;
 using CefSharp.Wpf;

--- a/src/BrowserHost/Tab/CefSharp/CefSharpTabBrowser.cs
+++ b/src/BrowserHost/Tab/CefSharp/CefSharpTabBrowser.cs
@@ -1,0 +1,89 @@
+﻿using BrowserHost.CefInfrastructure;
+using BrowserHost.Features.ActionContext;
+using BrowserHost.Features.ActionContext.FileDownloads;
+using BrowserHost.Features.ActionContext.Tabs;
+using BrowserHost.Features.CustomWindowChrome;
+using BrowserHost.Features.DragDrop;
+using BrowserHost.Features.TabPalette.FindText;
+using BrowserHost.Utilities;
+using CefSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+
+namespace BrowserHost.Tab.CefSharp;
+
+public class CefSharpTabBrowser : Browser
+{
+    private readonly ActionContextBrowser _actionContextBrowser;
+
+    public string Id { get; }
+    public string? Favicon { get; private set; }
+    public string? ManualAddress { get; private set; }
+
+    public CefSharpTabBrowser(string id, string address, ActionContextBrowser actionContextBrowser, bool setManualAddress, string? favicon)
+    {
+        Id = id;
+        Favicon = favicon;
+        SetAddress(address, setManualAddress);
+
+        TitleChanged += OnTitleChanged;
+        LoadingStateChanged += OnLoadingStateChanged;
+
+        DisplayHandler = new FaviconDisplayHandler(OnFaviconAddressesChanged);
+        _actionContextBrowser = actionContextBrowser;
+
+        var downloadsPath = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
+        DownloadHandler = new DownloadHandler(downloadsPath);
+        RequestHandler = new RequestHandler(Id);
+        FindHandler = new FindHandler();
+
+        BrowserSettings.BackgroundColor = Cef.ColorSetARGB(255, 255, 255, 255);
+    }
+
+    private void OnTitleChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        _actionContextBrowser.UpdateTabTitle(Id, (string)e.NewValue);
+    }
+
+    private void OnFaviconAddressesChanged(IList<string> addresses)
+    {
+        Favicon = addresses.FirstOrDefault();
+        PubSub.Publish(new TabFaviconUrlChangedEvent(Id, Favicon));
+        Dispatcher.BeginInvoke(() => _actionContextBrowser.UpdateTabFavicon(Id, Favicon));
+    }
+
+    private void OnLoadingStateChanged(object? sender, LoadingStateChangedEventArgs e)
+    {
+        PubSub.Publish(new TabLoadingStateChangedEvent(Id, e.IsLoading));
+    }
+
+    public void SetAddress(string address, bool setManualAddress)
+    {
+        Address = address;
+        if (setManualAddress)
+            ManualAddress = address;
+    }
+
+    protected override void OnAddressChanged(string oldValue, string newValue)
+    {
+        if (DragDropFeature.IsDragging && oldValue != null && newValue.StartsWith("file://"))
+        {
+            // This is a workaround to prevent the current address from being set
+            // when dragging and dropping files into the browser. Instead, we want
+            // open a new tab with the file URL. This is not directly possible,
+            // so we have to revert the change 
+            GetBrowser().GoBack();
+        }
+        else
+        {
+            base.OnAddressChanged(oldValue, newValue);
+        }
+    }
+
+    public void RegisterContentPageApi<TApi>(TApi api, string name) where TApi : BrowserApi
+    {
+        RegisterSecondaryApi(api, name);
+    }
+}

--- a/src/BrowserHost/Tab/CefSharp/CefSharpTabBrowserAdapter.cs
+++ b/src/BrowserHost/Tab/CefSharp/CefSharpTabBrowserAdapter.cs
@@ -46,5 +46,15 @@ public class CefSharpTabBrowserAdapter(string id, string address, ActionContextB
     public void StopFinding(bool clearSelection) => _cefBrowser.StopFinding(clearSelection);
     public UIElement AsUIElement() => _cefBrowser;
     public void ShowDevTools() => _cefBrowser.ShowDevTools();
-    public void CloseDevTools() => _cefBrowser.CloseDevTools();
+    public void CloseDevTools()
+    {
+        try
+        {
+            _cefBrowser.CloseDevTools();
+        }
+        catch
+        {
+            // Might fail if the tab is disposed
+        }
+    }
 }

--- a/src/BrowserHost/Tab/CefSharp/CefSharpTabBrowserAdapter.cs
+++ b/src/BrowserHost/Tab/CefSharp/CefSharpTabBrowserAdapter.cs
@@ -1,0 +1,50 @@
+﻿using BrowserHost.CefInfrastructure;
+using BrowserHost.Features.ActionContext;
+using CefSharp;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace BrowserHost.Tab.CefSharp;
+
+public class CefSharpTabBrowserAdapter(string id, string address, ActionContextBrowser actionContextBrowser, bool setManualAddress, string? favicon) : ITabWebBrowser
+{
+    private readonly CefSharpTabBrowser _cefBrowser = new(id, address, actionContextBrowser, setManualAddress, favicon);
+
+    public string Id => _cefBrowser.Id;
+    public string? Favicon => _cefBrowser.Favicon;
+    public string? ManualAddress => _cefBrowser.ManualAddress;
+    public string Address => _cefBrowser.Address;
+    public string Title
+    {
+        get => _cefBrowser.Title;
+        set => _cefBrowser.Title = value;
+    }
+    public bool IsLoading => _cefBrowser.IsLoading;
+    public bool CanGoBack => _cefBrowser.CanGoBack;
+    public bool CanGoForward => _cefBrowser.CanGoForward;
+    public double DefaultZoomLevel => 0.0;
+
+    public bool HasDevTools => _cefBrowser.GetBrowserHost().HasDevTools;
+
+    public event DependencyPropertyChangedEventHandler? AddressChanged
+    {
+        add => _cefBrowser.AddressChanged += value;
+        remove => _cefBrowser.AddressChanged -= value;
+    }
+
+    public void SetAddress(string address, bool setManualAddress) => _cefBrowser.SetAddress(address, setManualAddress);
+    public void RegisterContentPageApi(BrowserApi api, string name) => _cefBrowser.RegisterContentPageApi(api, name);
+    public void Reload(bool ignoreCache = false) => _cefBrowser.Reload(ignoreCache);
+    public void Dispose() => _cefBrowser.Dispose();
+    public void Back() => _cefBrowser.Back();
+    public void Forward() => _cefBrowser.Forward();
+    public Task CallClientApi(string api, string? arguments = null) { _cefBrowser.CallClientApi(api, arguments); return Task.CompletedTask; }
+    public object? GetBrowserHost() => _cefBrowser.GetBrowserHost();
+    public Task<double> GetZoomLevelAsync() => _cefBrowser.GetZoomLevelAsync();
+    public void SetZoomLevel(double level) => _cefBrowser.SetZoomLevel(level);
+    public void Find(string searchText, bool forward, bool matchCase, bool findNext) => _cefBrowser.Find(searchText, forward, matchCase, findNext);
+    public void StopFinding(bool clearSelection) => _cefBrowser.StopFinding(clearSelection);
+    public UIElement AsUIElement() => _cefBrowser;
+    public void ShowDevTools() => _cefBrowser.ShowDevTools();
+    public void CloseDevTools() => _cefBrowser.CloseDevTools();
+}

--- a/src/BrowserHost/Tab/ITabWebBrowser.cs
+++ b/src/BrowserHost/Tab/ITabWebBrowser.cs
@@ -1,0 +1,36 @@
+﻿using BrowserHost.CefInfrastructure;
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace BrowserHost.Tab;
+
+public interface ITabWebBrowser : IDisposable
+{
+    string Id { get; }
+    string? Favicon { get; }
+    string? ManualAddress { get; }
+    string Address { get; }
+    string Title { get; set; }
+    bool IsLoading { get; }
+    bool CanGoBack { get; }
+    bool CanGoForward { get; }
+    bool HasDevTools { get; }
+    double DefaultZoomLevel { get; }
+
+    event DependencyPropertyChangedEventHandler? AddressChanged;
+
+    void SetAddress(string address, bool setManualAddress);
+    void RegisterContentPageApi(BrowserApi api, string name);
+    void Reload(bool ignoreCache = false);
+    void Back();
+    void Forward();
+    Task CallClientApi(string api, string? arguments = null);
+    Task<double> GetZoomLevelAsync();
+    void SetZoomLevel(double level);
+    void Find(string searchText, bool forward, bool matchCase, bool findNext);
+    void StopFinding(bool clearSelection);
+    UIElement AsUIElement();
+    void ShowDevTools();
+    void CloseDevTools();
+}

--- a/src/BrowserHost/Tab/TabBrowser.cs
+++ b/src/BrowserHost/Tab/TabBrowser.cs
@@ -3,6 +3,7 @@ using BrowserHost.Features.ActionContext;
 using BrowserHost.Features.Settings;
 using BrowserHost.Tab.CefSharp;
 using BrowserHost.Tab.WebView2;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
@@ -60,7 +61,7 @@ public class TabBrowser : UserControl
         return _ssoDomains.Any(domain => HasDomain(address, domain));
     }
 
-    private static bool HasDomain(string address, string domain)
+    private static bool HasDomain2(string address, string domain)
     {
         if (string.IsNullOrWhiteSpace(address) || string.IsNullOrWhiteSpace(domain))
             return false;
@@ -70,6 +71,18 @@ public class TabBrowser : UserControl
             normalizedAddress = normalizedAddress.Substring(4);
 
         return normalizedAddress.StartsWith(domain);
+    }
+
+    private static bool HasDomain(string address, string domain)
+    {
+        if (string.IsNullOrWhiteSpace(address) || string.IsNullOrWhiteSpace(domain)) return false;
+        // Ensure absolute URI for reliable parsing
+        var candidate = address.Contains("://", StringComparison.Ordinal) ? address : "https://" + address;
+        if (!Uri.TryCreate(candidate, UriKind.Absolute, out var uri)) return false;
+        var host = uri.Host.TrimEnd('.').ToLowerInvariant();
+        var d = domain.Trim().TrimStart('.').ToLowerInvariant();
+        // Allow exact host or subdomain match on a dot boundary
+        return host == d || host.EndsWith("." + d, StringComparison.Ordinal);
     }
 
     private void AttachBrowserEvents()

--- a/src/BrowserHost/Tab/TabBrowser.cs
+++ b/src/BrowserHost/Tab/TabBrowser.cs
@@ -1,5 +1,7 @@
 ﻿using BrowserHost.CefInfrastructure;
+using BrowserHost.Features.ActionContext;
 using BrowserHost.Features.ActionContext.FileDownloads;
+using BrowserHost.Features.ActionContext.Tabs;
 using BrowserHost.Features.CustomWindowChrome;
 using BrowserHost.Features.DragDrop;
 using BrowserHost.Features.TabPalette.FindText;
@@ -10,7 +12,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 
-namespace BrowserHost.Features.ActionContext.Tabs;
+namespace BrowserHost.Tab;
 
 public class TabBrowser : Browser
 {

--- a/src/BrowserHost/Tab/TabBrowser.cs
+++ b/src/BrowserHost/Tab/TabBrowser.cs
@@ -37,10 +37,10 @@ public class TabBrowser : UserControl
     public bool CanGoForward => _browser.CanGoForward;
     public bool HasDevTools => _browser.HasDevTools;
 
-    public TabBrowser(string id, string address, ActionContextBrowser actionContextBrowser, bool setManualAddress, string? favicon, SettingsDataV1 settings)
+    public TabBrowser(string id, string address, ActionContextBrowser actionContextBrowser, bool setManualAddress, string? favicon)
     {
         _actionContextBrowser = actionContextBrowser;
-        _ssoDomains = settings.SsoEnabledDomains ?? [];
+        _ssoDomains = SettingsFeature.ExecutionSettings.SsoEnabledDomains ?? [];
         _browser = CreateBrowser(id, address, setManualAddress, favicon);
         Content = _browser.AsUIElement();
         AttachBrowserEvents();

--- a/src/BrowserHost/Tab/TabBrowser.cs
+++ b/src/BrowserHost/Tab/TabBrowser.cs
@@ -61,18 +61,6 @@ public class TabBrowser : UserControl
         return _ssoDomains.Any(domain => HasDomain(address, domain));
     }
 
-    private static bool HasDomain2(string address, string domain)
-    {
-        if (string.IsNullOrWhiteSpace(address) || string.IsNullOrWhiteSpace(domain))
-            return false;
-
-        var normalizedAddress = address.Contains("://") ? address.Split("://")[1] : address;
-        if (normalizedAddress.StartsWith("www."))
-            normalizedAddress = normalizedAddress.Substring(4);
-
-        return normalizedAddress.StartsWith(domain);
-    }
-
     private static bool HasDomain(string address, string domain)
     {
         if (string.IsNullOrWhiteSpace(address) || string.IsNullOrWhiteSpace(domain)) return false;

--- a/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
+++ b/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
@@ -2,6 +2,7 @@
 using BrowserHost.Features.ActionContext;
 using BrowserHost.Features.ActionContext.Tabs;
 using BrowserHost.Features.ActionDialog;
+using BrowserHost.Features.CustomWindowChrome;
 using BrowserHost.Utilities;
 using Microsoft.Web.WebView2.Core;
 using System;
@@ -126,10 +127,15 @@ public sealed class WebView2Browser : UserControl, ITabWebBrowser, IDisposable
     private void WireCoreEvents(ActionContextBrowser actionContextBrowser)
     {
         if (_core == null) return;
-        _core.NavigationStarting += (_, __) => _isLoading = true;
+        _core.NavigationStarting += (_, __) =>
+        {
+            _isLoading = true;
+            PubSub.Publish(new TabLoadingStateChangedEvent(_id, true));
+        };
         _core.NavigationCompleted += (_, args) =>
         {
             _isLoading = false;
+            PubSub.Publish(new TabLoadingStateChangedEvent(_id, false));
             var newAddress = _core.Source;
             if (_lastAddressSnapshot != newAddress)
             {

--- a/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
+++ b/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
@@ -299,6 +299,7 @@ public sealed class WebView2Browser : UserControl, ITabWebBrowser, IDisposable
             if (_core != null)
             {
                 _core.NewWindowRequested -= Core_NewWindowRequested;
+                _core = null;
             }
             if (_controller != null)
             {

--- a/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
+++ b/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
@@ -1,0 +1,298 @@
+﻿using BrowserHost.CefInfrastructure;
+using BrowserHost.Features.ActionContext;
+using BrowserHost.Features.ActionContext.Tabs;
+using BrowserHost.Features.ActionDialog;
+using BrowserHost.Utilities;
+using Microsoft.Web.WebView2.Core;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Interop;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace BrowserHost.Tab.WebView2;
+
+public sealed class WebView2Browser : UserControl, ITabWebBrowser, IDisposable
+{
+    private static CoreWebView2Environment? _sharedEnvironment;
+    private readonly string _id;
+    private readonly string? _initialManualAddress;
+    private readonly string? _initialFavicon;
+    private string? _manualAddress;
+    private string? _favicon;
+    private string _title = string.Empty;
+    private bool _isLoading;
+    private CoreWebView2Controller? _controller;
+    private CoreWebView2? _core;
+    private readonly Border _hostSurface = new() { Background = Brushes.Transparent };
+    private string? _pendingNavigateTo;
+    private string? _lastAddressSnapshot;
+    private Image? _snapshotImage;
+    private bool _snapshotActive;
+    private double _zoomFactor = 1.0; // track requested zoom
+
+    private static readonly DependencyProperty AddressProperty = DependencyProperty.Register(
+        nameof(Address), typeof(string), typeof(WebView2Browser), new PropertyMetadata(string.Empty));
+
+    public event DependencyPropertyChangedEventHandler? AddressChanged;
+
+    public WebView2Browser(string id, string address, ActionContextBrowser actionContextBrowser, bool setManualAddress, string? favicon)
+    {
+        _id = id;
+        _initialManualAddress = setManualAddress ? address : null;
+        _initialFavicon = favicon;
+        _manualAddress = _initialManualAddress;
+        _pendingNavigateTo = NormalizeAddress(address);
+        _hostSurface.Loaded += async (_, _) => { await EnsureControllerAsync(actionContextBrowser); SyncControllerVisibility(); };
+        _hostSurface.Unloaded += (_, _) => SyncControllerVisibility();
+        _hostSurface.IsVisibleChanged += (_, _) => SyncControllerVisibility();
+        _hostSurface.SizeChanged += (_, _) => { UpdateControllerBounds(); };
+        _hostSurface.LayoutUpdated += (_, _) => { if (_hostSurface.IsVisible) UpdateControllerBounds(); };
+
+        // Subscribe to Action Dialog lifecycle to toggle snapshot overlay
+        PubSub.Subscribe<ActionDialogShownEvent>(_ => { if (_hostSurface.IsVisible) ActivateSnapshotAsync(); });
+        PubSub.Subscribe<ActionDialogDismissedEvent>(_ => { if (_snapshotActive) DeactivateSnapshot(); });
+    }
+
+    public string Id => _id;
+    public string? Favicon => _favicon ?? _initialFavicon;
+    public string? ManualAddress => _manualAddress ?? _initialManualAddress;
+    public string Address => _core?.Source ?? _pendingNavigateTo ?? string.Empty;
+    public string Title { get => _title; set => _title = value; }
+    public bool IsLoading => _isLoading;
+    public bool CanGoBack => _core?.CanGoBack ?? false;
+    public bool CanGoForward => _core?.CanGoForward ?? false;
+    public bool HasDevTools => false;
+    public double DefaultZoomLevel => 1.0;
+
+    private async Task EnsureControllerAsync(ActionContextBrowser actionContextBrowser)
+    {
+        if (_controller != null) return;
+        if (_sharedEnvironment == null)
+        {
+            var userDataFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "WebView2LowLevelCache");
+            Directory.CreateDirectory(userDataFolder);
+            var options = new CoreWebView2EnvironmentOptions
+            {
+                AllowSingleSignOnUsingOSPrimaryAccount = true,
+            };
+            _sharedEnvironment = await CoreWebView2Environment.CreateAsync(userDataFolder: userDataFolder, options: options);
+        }
+        var parentWindow = Window.GetWindow(_hostSurface);
+        if (parentWindow == null) return;
+        var hwnd = new WindowInteropHelper(parentWindow).Handle;
+        _controller = await _sharedEnvironment.CreateCoreWebView2ControllerAsync(hwnd);
+        _core = _controller.CoreWebView2;
+        UpdateControllerBounds();
+        WireCoreEvents(actionContextBrowser);
+        ApplySettings();
+        if (_pendingNavigateTo != null) { _core.Navigate(_pendingNavigateTo); _pendingNavigateTo = null; }
+    }
+
+    private void WireCoreEvents(ActionContextBrowser actionContextBrowser)
+    {
+        if (_core == null) return;
+        _core.NavigationStarting += (_, __) => _isLoading = true;
+        _core.NavigationCompleted += (_, __) =>
+        {
+            _isLoading = false;
+            var newAddress = _core.Source;
+            if (_lastAddressSnapshot != newAddress)
+            {
+                var previous = _lastAddressSnapshot;
+                _lastAddressSnapshot = newAddress;
+
+                AddressChanged?.Invoke(this, new DependencyPropertyChangedEventArgs(AddressProperty, previous, newAddress));
+            }
+            // Invalidate snapshot after navigation (so next dialog show captures fresh view)
+            if (_snapshotActive) RefreshSnapshotAsync();
+        };
+        _core.DocumentTitleChanged += (_, __) => { _title = _core.DocumentTitle; actionContextBrowser.UpdateTabTitle(_id, _title); };
+        _core.FaviconChanged += (_, __) => { _favicon = _core.FaviconUri; actionContextBrowser.UpdateTabFavicon(_id, _favicon); };
+        _controller!.AcceleratorKeyPressed += Controller_AcceleratorKeyPressed;
+    }
+
+    private void ApplySettings()
+    {
+        if (_core == null) return;
+
+        var settings = _core.Settings;
+        settings.AreDevToolsEnabled = true;
+        settings.AreDefaultContextMenusEnabled = false;
+        settings.AreBrowserAcceleratorKeysEnabled = true; // we consume them
+        // Apply zoom on controller if available
+        if (_controller != null)
+        {
+            try { _controller.ZoomFactor = _zoomFactor; } catch { }
+        }
+    }
+
+    private static readonly HashSet<Key> _allowedCtrlEditingKeys = [Key.C, Key.V, Key.X, Key.A, Key.Z, Key.Y];
+    private void Controller_AcceleratorKeyPressed(object? sender, CoreWebView2AcceleratorKeyPressedEventArgs e)
+    {
+        if (e.KeyEventKind is not (CoreWebView2KeyEventKind.KeyDown or CoreWebView2KeyEventKind.SystemKeyDown)) return;
+
+        var key = KeyInterop.KeyFromVirtualKey((int)e.VirtualKey);
+        var mods = Keyboard.Modifiers;
+        var ctrl = (mods & ModifierKeys.Control) != 0;
+        var alt = (mods & ModifierKeys.Alt) != 0;
+        var forward = false;
+
+        if (alt)
+        {
+            forward = true;
+        }
+        else if (key is Key.F5 or Key.F12)
+        {
+            forward = true;
+        }
+        else if (ctrl && !_allowedCtrlEditingKeys.Contains(key))
+        {
+            forward = true;
+        }
+        else if (ctrl && key == Key.Tab)
+        {
+            forward = true;
+        }
+
+        if (forward)
+        {
+            e.Handled = true;
+            var source = PresentationSource.FromVisual(MainWindow.Instance);
+            if (source != null)
+            {
+                var args = new KeyEventArgs(Keyboard.PrimaryDevice, source, Environment.TickCount, key) { RoutedEvent = Keyboard.PreviewKeyDownEvent };
+                MainWindow.Instance.ProcessKeyboardEvent(args);
+            }
+        }
+    }
+
+    private void SyncControllerVisibility()
+    {
+        if (_controller == null) return;
+
+        var shouldBeVisible = _hostSurface.IsVisible && !_snapshotActive;
+
+        if (_controller.IsVisible != shouldBeVisible)
+            _controller.IsVisible = shouldBeVisible;
+
+        if (shouldBeVisible)
+            UpdateControllerBounds();
+    }
+
+    private void UpdateControllerBounds()
+    {
+        if (_controller == null || _snapshotActive || !_hostSurface.IsVisible) return;
+        var window = Window.GetWindow(_hostSurface);
+        if (window == null) return;
+        var topLeft = _hostSurface.TranslatePoint(new Point(0, 0), window);
+        var size = new Size(_hostSurface.ActualWidth, _hostSurface.ActualHeight);
+        if (size.Width <= 0 || size.Height <= 0) return;
+        var ps = PresentationSource.FromVisual(window);
+        var dpiX = ps?.CompositionTarget?.TransformToDevice.M11 ?? 1.0;
+        var dpiY = ps?.CompositionTarget?.TransformToDevice.M22 ?? 1.0;
+        var x = (int)Math.Round(topLeft.X * dpiX);
+        var y = (int)Math.Round(topLeft.Y * dpiY);
+        var w = (int)Math.Round(size.Width * dpiX);
+        var h = (int)Math.Round(size.Height * dpiY);
+        _controller.Bounds = new System.Drawing.Rectangle(x, y, w, h);
+    }
+
+    private async void ActivateSnapshotAsync()
+    {
+        if (_snapshotActive || _core == null || _controller == null || !_hostSurface.IsVisible) return;
+
+        try
+        {
+            using var ms = new MemoryStream();
+            await _core.CapturePreviewAsync(CoreWebView2CapturePreviewImageFormat.Png, ms);
+            ms.Position = 0;
+            var bmp = new BitmapImage();
+            bmp.BeginInit(); bmp.CacheOption = BitmapCacheOption.OnLoad; bmp.StreamSource = ms; bmp.EndInit(); bmp.Freeze();
+            _snapshotImage = new Image { Source = bmp, Stretch = Stretch.Fill, HorizontalAlignment = HorizontalAlignment.Stretch, VerticalAlignment = VerticalAlignment.Stretch };
+            _hostSurface.Child = _snapshotImage;
+            _controller.IsVisible = false;
+            _snapshotActive = true;
+        }
+        catch { /* ignore */ }
+    }
+
+    private async void RefreshSnapshotAsync()
+    {
+        if (!_snapshotActive || _core == null) return;
+        try
+        {
+            using var ms = new MemoryStream();
+            await _core.CapturePreviewAsync(CoreWebView2CapturePreviewImageFormat.Png, ms);
+            ms.Position = 0;
+            var bmp = new BitmapImage();
+            bmp.BeginInit(); bmp.CacheOption = BitmapCacheOption.OnLoad; bmp.StreamSource = ms; bmp.EndInit(); bmp.Freeze();
+            if (_snapshotImage != null) _snapshotImage.Source = bmp;
+        }
+        catch { }
+    }
+
+    private void DeactivateSnapshot()
+    {
+        if (!_snapshotActive) return;
+        _hostSurface.Child = null;
+        _snapshotImage = null;
+        _snapshotActive = false;
+        SyncControllerVisibility();
+    }
+
+    public void SetAddress(string address, bool setManualAddress)
+    {
+        var normalized = NormalizeAddress(address);
+        if (setManualAddress) _manualAddress = address;
+        if (_core == null) { _pendingNavigateTo = normalized; return; }
+        if (normalized != null) _core.Navigate(normalized);
+    }
+
+    public void RegisterContentPageApi(BrowserApi api, string name) => _core?.AddHostObjectToScript(name, api);
+    public void Reload(bool ignoreCache = false) => _core?.Reload();
+    public void Back() { if (CanGoBack) _core?.GoBack(); }
+    public void Forward() { if (CanGoForward) _core?.GoForward(); }
+    public async Task CallClientApi(string api, string? arguments = null) { if (_core != null) await _core.ExecuteScriptAsync($"{api}({arguments ?? string.Empty});"); }
+    public Task<double> GetZoomLevelAsync() => Task.FromResult(_controller?.ZoomFactor ?? _zoomFactor);
+
+    public void SetZoomLevel(double level)
+    {
+        var clamped = Math.Clamp(level, 0.25, 5.0); // WebView2 supported range
+        _zoomFactor = clamped;
+        if (_controller != null)
+        {
+            try { _controller.ZoomFactor = clamped; } catch { }
+        }
+    }
+    public void Find(string searchText, bool forward, bool matchCase, bool findNext) { }
+    public void StopFinding(bool clearSelection) { }
+    public UIElement AsUIElement() => _hostSurface;
+    public void ShowDevTools() => _core?.OpenDevToolsWindow();
+    public void CloseDevTools() { }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (_controller != null)
+            {
+                _controller.AcceleratorKeyPressed -= Controller_AcceleratorKeyPressed;
+                _controller.Close();
+            }
+        }
+        catch { }
+    }
+
+    private static string? NormalizeAddress(string address)
+    {
+        if (string.IsNullOrWhiteSpace(address)) return null;
+        if (!Uri.TryCreate(address, UriKind.Absolute, out var uri) || string.IsNullOrEmpty(uri.Scheme)) return "https://" + address;
+        return address;
+    }
+}

--- a/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
+++ b/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
@@ -284,6 +284,7 @@ public sealed class WebView2Browser : UserControl, ITabWebBrowser, IDisposable
             {
                 _controller.AcceleratorKeyPressed -= Controller_AcceleratorKeyPressed;
                 _controller.Close();
+                _controller = null;
             }
         }
         catch { }

--- a/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
+++ b/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
@@ -267,7 +267,7 @@ public sealed class WebView2Browser : UserControl, ITabWebBrowser, IDisposable
         else return Dispatcher.Invoke(action);
     }
 
-    public void RegisterContentPageApi(BrowserApi api, string name) => _core?.AddHostObjectToScript(name, api);
+    public void RegisterContentPageApi(BrowserApi api, string name) => throw new InvalidOperationException("The WebView2Browser does not support content pages");
     public void Reload(bool ignoreCache = false) => RunOnUi(() => _core?.Reload());
     public void Back() { if (CanGoBack) RunOnUi(() => _core?.GoBack()); }
     public void Forward() { if (CanGoForward) RunOnUi(() => _core?.GoForward()); }

--- a/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
+++ b/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
@@ -43,6 +43,9 @@ public sealed class WebView2Browser : UserControl, ITabWebBrowser, IDisposable
     private readonly WebView2FindManager _findManager = new();
     private readonly WebView2RoundedCornerManager _roundedCornerManager = new(CornerRadiusPx);
 
+    // Cache of last applied bounds to avoid redundant work
+    private int _lastX = -1, _lastY = -1, _lastW = -1, _lastH = -1;
+
     private static readonly DependencyProperty AddressProperty = DependencyProperty.Register(
         nameof(Address), typeof(string), typeof(WebView2Browser), new PropertyMetadata(string.Empty));
 
@@ -212,6 +215,9 @@ public sealed class WebView2Browser : UserControl, ITabWebBrowser, IDisposable
         var y = (int)Math.Round(topLeft.Y * dpiY);
         var w = (int)Math.Round(size.Width * dpiX);
         var h = (int)Math.Round(size.Height * dpiY);
+        // Skip if bounds unchanged
+        if (x == _lastX && y == _lastY && w == _lastW && h == _lastH) return;
+        _lastX = x; _lastY = y; _lastW = w; _lastH = h;
         _controller.Bounds = new System.Drawing.Rectangle(x, y, w, h);
         _roundedCornerManager.ApplyRoundedRegion(w, h);
     }

--- a/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
+++ b/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
@@ -143,7 +143,6 @@ public sealed class WebView2Browser : UserControl, ITabWebBrowser, IDisposable
                 _lastAddressSnapshot = newAddress;
                 AddressChanged?.Invoke(this, new DependencyPropertyChangedEventArgs(AddressProperty, previous, newAddress));
             }
-            _snapshotOverlay.OnNavigationCompleted(success: args.IsSuccess, _core);
         };
         _core.DocumentTitleChanged += (_, __) => { _title = _core.DocumentTitle; actionContextBrowser.UpdateTabTitle(_id, _title); };
         _core.FaviconChanged += (_, __) => { _favicon = _core.FaviconUri; actionContextBrowser.UpdateTabFavicon(_id, _favicon); };

--- a/src/BrowserHost/Tab/WebView2/WebView2FindManager.cs
+++ b/src/BrowserHost/Tab/WebView2/WebView2FindManager.cs
@@ -10,6 +10,7 @@ internal sealed class WebView2FindManager
 {
     private CoreWebView2? _core;
     private string? _findTerm;
+    private bool _matchCase;
     private int _findIndex;
     private int _findCount;
 
@@ -24,10 +25,11 @@ internal sealed class WebView2FindManager
         if (_core == null) return;
         if (string.IsNullOrWhiteSpace(searchText)) { StopFinding(true); return; }
 
-        // New term => highlight first then navigate.
-        if (_findTerm != searchText)
+        // New search if term or matchCase changed, or caller indicates not findNext
+        if (_findTerm != searchText || _matchCase != matchCase || !findNext)
         {
             _findTerm = searchText;
+            _matchCase = matchCase;
             _findIndex = 0;
             _ = RunHighlightAsync(searchText, matchCase);
             return;

--- a/src/BrowserHost/Tab/WebView2/WebView2FindManager.cs
+++ b/src/BrowserHost/Tab/WebView2/WebView2FindManager.cs
@@ -1,0 +1,187 @@
+using BrowserHost.Features.TabPalette.FindText;
+using BrowserHost.Utilities;
+using Microsoft.Web.WebView2.Core;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace BrowserHost.Tab.WebView2;
+
+internal sealed class WebView2FindManager
+{
+    private CoreWebView2? _core;
+    private string? _findTerm;
+    private int _findIndex;
+    private int _findCount;
+
+    public void Initialize(CoreWebView2 core)
+    {
+        _core = core;
+        StopFinding(true);
+    }
+
+    public void Find(string searchText, bool forward, bool matchCase, bool findNext)
+    {
+        if (_core == null) return;
+        if (string.IsNullOrWhiteSpace(searchText)) { StopFinding(true); return; }
+
+        // New term => highlight first then navigate.
+        if (_findTerm != searchText)
+        {
+            _findTerm = searchText;
+            _findIndex = 0;
+            _ = RunHighlightAsync(searchText, matchCase);
+            return;
+        }
+
+        if (_findCount == 0) return;
+
+        _findIndex = (_findIndex + (forward ? 1 : -1) + _findCount) % _findCount;
+        _ = NavigateToCurrentAsync();
+    }
+
+    private async Task RunHighlightAsync(string term, bool matchCase)
+    {
+        if (_core == null) return;
+        var js = """
+                (function() {
+                  const term = TERM_PLACEHOLDER;
+                  const matchCase = MATCHCASE_PLACEHOLDER;
+                  const CLASS = '__ch_find_highlight';
+                  // Remove old
+                  const old = document.querySelectorAll('span.'+CLASS);
+                  old.forEach(span => {
+                    const parent = span.parentNode;
+                    while (span.firstChild) parent.insertBefore(span.firstChild, span);
+                    parent.removeChild(span);
+                    parent && parent.normalize();
+                  });
+                  if (!term) return 0;
+                  const esc = term.replace(/[.*+?^${}()|[\]\\]/g, r => '\\' + r);
+                  const re = new RegExp(esc, matchCase ? 'g' : 'gi');
+                  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+                  let count = 0;
+                  const textNodes = [];
+                  while (walker.nextNode()) textNodes.push(walker.currentNode);
+
+                  const skipTags = new Set(['SCRIPT','STYLE','NOSCRIPT','TEMPLATE','HEAD','META','TITLE']);
+                  function isVisible(node) {
+                    let el = node.parentElement;
+                    if (!el) return false;
+                    while (el) {
+                      if (skipTags.has(el.tagName)) return false;
+                      if (el.hasAttribute('hidden')) return false;
+                      if (el.getAttribute && el.getAttribute('aria-hidden') === 'true') return false;
+                      const cs = window.getComputedStyle(el);
+                      if (cs.display === 'none' || cs.visibility === 'hidden' || cs.opacity === '0') return false;
+                      if (el === document.body) return true;
+                      el = el.parentElement;
+                    }
+                    return false;
+                  }
+
+                  for (const n of textNodes) {
+                    if (!isVisible(n)) continue;
+                    const txt = n.nodeValue;
+                    if (!txt || !re.test(txt)) { re.lastIndex = 0; continue; }
+                    re.lastIndex = 0;
+                    let m; let last = 0; let frag = null;
+                    while ((m = re.exec(txt)) !== null) {
+                      if (!frag) frag = document.createDocumentFragment();
+                      const before = txt.slice(last, m.index); if (before) frag.appendChild(document.createTextNode(before));
+                      const span = document.createElement('span');
+                      span.className = CLASS;
+                      span.style.backgroundColor = 'rgba(255,255,0,0.6)';
+                      span.style.color = 'black';
+                      span.textContent = m[0];
+                      frag.appendChild(span);
+                      last = m.index + m[0].length;
+                      count++;
+                    }
+                    if (frag) {
+                      const after = txt.slice(last); if (after) frag.appendChild(document.createTextNode(after));
+                      n.parentNode.replaceChild(frag, n);
+                    }
+                  }
+                  return count;
+                })();
+                """;
+        js = js.Replace("TERM_PLACEHOLDER", JsonSerializer.Serialize(term))
+               .Replace("MATCHCASE_PLACEHOLDER", matchCase ? "true" : "false");
+        try
+        {
+            var result = await _core.ExecuteScriptAsync(js);
+            if (int.TryParse(result, out var count))
+            {
+                _findCount = count;
+                PubSub.Publish(new FindStatusChangedEvent(count));
+                if (count > 0)
+                {
+                    _findIndex = 0;
+                    await NavigateToCurrentAsync();
+                }
+            }
+        }
+        catch { }
+    }
+
+    private async Task NavigateToCurrentAsync()
+    {
+        if (_core == null || _findCount == 0) return;
+        var js = """
+                (function(){
+                  const CLASS='__ch_find_highlight';
+                  const ACTIVE='__ch_find_active';
+                  const spans=Array.from(document.querySelectorAll('span.'+CLASS));
+                  spans.forEach((s,i)=>{
+                    if (i === FIND_INDEX_PLACEHOLDER) {
+                      s.classList.add(ACTIVE);
+                      s.style.outline='2px solid orange';
+                      s.scrollIntoView({block:'center'});
+                    } else {
+                      s.classList.remove(ACTIVE);
+                      s.style.outline='';
+                    }
+                  });
+                  return spans.length;
+                })();
+                """;
+        js = js.Replace("FIND_INDEX_PLACEHOLDER", _findIndex.ToString());
+        try
+        {
+            var result = await _core.ExecuteScriptAsync(js);
+            if (int.TryParse(result, out var count) && count != _findCount)
+            {
+                _findCount = count;
+                PubSub.Publish(new FindStatusChangedEvent(count));
+            }
+        }
+        catch { }
+    }
+
+    public void StopFinding(bool clearSelection)
+    {
+        _findTerm = null;
+        _findIndex = 0;
+        _findCount = 0;
+        if (_core == null) return;
+        var js = """
+                (function(){
+                  const CLASS='__ch_find_highlight';
+                  const spans=document.querySelectorAll('span.'+CLASS);
+                  spans.forEach(span=>{
+                    const parent=span.parentNode;
+                    while(span.firstChild) parent.insertBefore(span.firstChild, span);
+                    parent.removeChild(span);
+                    parent && parent.normalize();
+                  });
+                  CLEAR_SEL_PLACEHOLDER
+                })();
+                """;
+        if (clearSelection)
+            js = js.Replace("CLEAR_SEL_PLACEHOLDER", "try { window.getSelection().removeAllRanges(); } catch {}");
+        else
+            js = js.Replace("CLEAR_SEL_PLACEHOLDER", string.Empty);
+        _ = _core.ExecuteScriptAsync(js);
+        PubSub.Publish(new FindStatusChangedEvent(0));
+    }
+}

--- a/src/BrowserHost/Tab/WebView2/WebView2RoundedCornerManager.cs
+++ b/src/BrowserHost/Tab/WebView2/WebView2RoundedCornerManager.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Threading;
+
+namespace BrowserHost.Tab.WebView2;
+
+internal sealed class WebView2RoundedCornerManager
+{
+    private readonly int _cornerRadiusPx;
+    private IntPtr _parentHwnd;
+    private IntPtr _childWebViewHwnd;
+    private bool _enumeratedChild;
+
+    public WebView2RoundedCornerManager(int cornerRadiusPx)
+    {
+        _cornerRadiusPx = cornerRadiusPx;
+    }
+
+    public void SetParentWindowHandle(IntPtr hwnd)
+    {
+        if (_parentHwnd != hwnd)
+        {
+            _parentHwnd = hwnd;
+            _enumeratedChild = false;
+            _childWebViewHwnd = IntPtr.Zero;
+        }
+    }
+
+    public void EnsureChildWindowAsync(Dispatcher dispatcher, Func<int> getWidth, Func<int> getHeight)
+    {
+        if (_enumeratedChild || _parentHwnd == IntPtr.Zero) return;
+        _enumeratedChild = true;
+        dispatcher.BeginInvoke(async () =>
+        {
+            for (var i = 0; i < 6 && _childWebViewHwnd == IntPtr.Zero; i++)
+            {
+                EnumerateChildWindows();
+                if (_childWebViewHwnd != IntPtr.Zero) break;
+                await Task.Delay(50);
+            }
+            if (_childWebViewHwnd != IntPtr.Zero)
+            {
+                ApplyRoundedRegion(getWidth(), getHeight());
+            }
+        });
+    }
+
+    public void ApplyRoundedRegion(int width, int height)
+    {
+        if (_childWebViewHwnd == IntPtr.Zero || width <= 0 || height <= 0) return;
+        var r = _cornerRadiusPx * 2;
+        var region = CreateRoundRectRgn(0, 0, width + 1, height + 1, r, r);
+        if (region != IntPtr.Zero)
+        {
+            SetWindowRgn(_childWebViewHwnd, region, true);
+        }
+    }
+
+    private void EnumerateChildWindows()
+    {
+        EnumChildWindows(_parentHwnd, (hWnd, _) =>
+        {
+            var cls = GetClassName(hWnd);
+            if (cls.StartsWith("Chrome_WidgetWin_", StringComparison.Ordinal))
+            {
+                _childWebViewHwnd = hWnd;
+                return false; // stop enumeration
+            }
+            return true; // continue
+        }, IntPtr.Zero);
+    }
+
+    // P/Invoke
+    private delegate bool EnumChildProc(IntPtr hWnd, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    private static extern bool EnumChildWindows(IntPtr hWndParent, EnumChildProc lpEnumFunc, IntPtr lParam);
+
+    [DllImport("user32.dll", CharSet = CharSet.Auto)]
+    private static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateRoundRectRgn(int nLeftRect, int nTopRect, int nRightRect, int nBottomRect, int nWidthEllipse, int nHeightEllipse);
+
+    [DllImport("user32.dll")]
+    private static extern int SetWindowRgn(IntPtr hWnd, IntPtr hRgn, bool bRedraw);
+
+    private static string GetClassName(IntPtr hWnd)
+    {
+        var sb = new StringBuilder(256);
+        GetClassName(hWnd, sb, sb.Capacity);
+        return sb.ToString();
+    }
+}

--- a/src/BrowserHost/Tab/WebView2/WebView2RoundedCornerManager.cs
+++ b/src/BrowserHost/Tab/WebView2/WebView2RoundedCornerManager.cs
@@ -54,7 +54,12 @@ internal sealed class WebView2RoundedCornerManager
         var region = CreateRoundRectRgn(0, 0, width + 1, height + 1, r, r);
         if (region != IntPtr.Zero)
         {
-            SetWindowRgn(_childWebViewHwnd, region, true);
+            var result = SetWindowRgn(_childWebViewHwnd, region, true);
+            if (result == 0)
+            {
+                // OS did not take ownership; delete to prevent leak
+                DeleteObject(region);
+            }
         }
     }
 
@@ -86,6 +91,9 @@ internal sealed class WebView2RoundedCornerManager
 
     [DllImport("user32.dll")]
     private static extern int SetWindowRgn(IntPtr hWnd, IntPtr hRgn, bool bRedraw);
+
+    [DllImport("gdi32.dll")]
+    private static extern bool DeleteObject(IntPtr hObject);
 
     private static string GetClassName(IntPtr hWnd)
     {

--- a/src/BrowserHost/Tab/WebView2/WebView2SnapshotOverlay.cs
+++ b/src/BrowserHost/Tab/WebView2/WebView2SnapshotOverlay.cs
@@ -34,7 +34,7 @@ internal sealed class WebView2SnapshotOverlay
     public async Task<bool> TryActivateAsync(CoreWebView2 core)
     {
         if (IsActive) return true;
-        await CaptureAsync(core, preload: false);
+        await CaptureAsync(core);
         if (_image.Source == null) return false;
         _image.Visibility = System.Windows.Visibility.Visible;
         await AwaitRenderAsync();
@@ -49,7 +49,7 @@ internal sealed class WebView2SnapshotOverlay
         _image.Visibility = System.Windows.Visibility.Collapsed;
     }
 
-    private async Task CaptureAsync(CoreWebView2 core, bool preload)
+    private async Task CaptureAsync(CoreWebView2 core)
     {
         try
         {

--- a/src/BrowserHost/Tab/WebView2/WebView2SnapshotOverlay.cs
+++ b/src/BrowserHost/Tab/WebView2/WebView2SnapshotOverlay.cs
@@ -1,0 +1,105 @@
+using Microsoft.Web.WebView2.Core;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace BrowserHost.Tab.WebView2;
+
+internal sealed class WebView2SnapshotOverlay
+{
+    private readonly Grid _root = new();
+    private readonly Image _image;
+    private bool _preloadInProgress;
+    private bool _hasSnapshot;
+    public bool IsActive { get; private set; }
+
+    public WebView2SnapshotOverlay()
+    {
+        _image = new Image
+        {
+            Stretch = Stretch.Fill,
+            HorizontalAlignment = System.Windows.HorizontalAlignment.Stretch,
+            VerticalAlignment = System.Windows.VerticalAlignment.Stretch,
+            Visibility = System.Windows.Visibility.Collapsed,
+            SnapsToDevicePixels = true,
+            UseLayoutRounding = true
+        };
+        RenderOptions.SetBitmapScalingMode(_image, BitmapScalingMode.LowQuality);
+        _root.Children.Add(_image);
+    }
+
+    public System.Windows.UIElement Visual => _root;
+
+    public void OnNavigationCompleted(bool success, CoreWebView2 core)
+    {
+        if (!success)
+        {
+            _hasSnapshot = false;
+            return;
+        }
+        _ = CaptureAsync(core, preload: true);
+    }
+
+    public async Task<bool> TryActivateAsync(CoreWebView2 core)
+    {
+        if (IsActive) return true;
+        if (!_hasSnapshot)
+            await CaptureAsync(core, preload: false);
+        if (_image.Source == null) return false;
+        _image.Visibility = System.Windows.Visibility.Visible;
+        await AwaitRenderAsync();
+        IsActive = true;
+        return true;
+    }
+
+    public void Deactivate()
+    {
+        if (!IsActive) return;
+        IsActive = false;
+        _image.Visibility = System.Windows.Visibility.Collapsed;
+    }
+
+    private async Task CaptureAsync(CoreWebView2 core, bool preload)
+    {
+        if (preload && _preloadInProgress) return;
+        if (preload) _preloadInProgress = true;
+        try
+        {
+            using var ms = new MemoryStream();
+            await core.CapturePreviewAsync(CoreWebView2CapturePreviewImageFormat.Png, ms);
+            ms.Position = 0;
+            var bmp = new BitmapImage();
+            bmp.BeginInit();
+            bmp.CacheOption = BitmapCacheOption.OnLoad;
+            bmp.StreamSource = ms;
+            bmp.CreateOptions = BitmapCreateOptions.IgnoreColorProfile;
+            bmp.EndInit();
+            bmp.Freeze();
+            _image.Source = bmp;
+            _hasSnapshot = true;
+        }
+        catch
+        {
+            if (!preload) _hasSnapshot = false;
+        }
+        finally
+        {
+            if (preload) _preloadInProgress = false;
+        }
+    }
+
+    private static Task AwaitRenderAsync()
+    {
+        var tcs = new TaskCompletionSource();
+        void Handler(object? s, EventArgs e)
+        {
+            CompositionTarget.Rendering -= Handler;
+            tcs.TrySetResult();
+        }
+        CompositionTarget.Rendering += Handler;
+        return tcs.Task;
+    }
+}

--- a/src/BrowserHost/Utilities/DataComparisons.cs
+++ b/src/BrowserHost/Utilities/DataComparisons.cs
@@ -1,0 +1,16 @@
+﻿namespace BrowserHost.Utilities;
+
+public static class DataComparisons
+{
+    public static bool AreArraysEqual(string[]? a, string[]? b)
+    {
+        if (a is null && b is null) return true;
+        if (a is null || b is null) return false;
+        if (a.Length != b.Length) return false;
+        for (var i = 0; i < a.Length; i++)
+        {
+            if (a[i] != b[i]) return false;
+        }
+        return true;
+    }
+}

--- a/src/chrome-app/src/app/content-pages/settings/settings-page.component.ts
+++ b/src/chrome-app/src/app/content-pages/settings/settings-page.component.ts
@@ -62,6 +62,48 @@ import { settingsSchema } from './settings-schema';
                 (ngModelChange)="onStringChange(field.key, $event)"
                 [placeholder]="field.placeholder ?? ''"
               />
+              } @else if (field.type === 'string[]') {
+              <div class="flex flex-col gap-2">
+                <div class="flex flex-wrap gap-2">
+                  @for (item of asStringArray(getValue(field.key)); let i =
+                  $index; track i) {
+                  <div
+                    class="flex items-center gap-1 bg-gray-800 px-2 py-1 rounded text-xs"
+                  >
+                    <input
+                      type="text"
+                      class="bg-transparent focus:outline-none w-32"
+                      [ngModel]="item"
+                      (ngModelChange)="
+                        onStringArrayItemChange(field.key, i, $event)
+                      "
+                      [placeholder]="field.placeholder ?? ''"
+                    />
+                    <button
+                      type="button"
+                      class="text-red-300 hover:text-red-200"
+                      (click)="removeStringArrayItem(field.key, i)"
+                      aria-label="Remove"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                  }
+                  <button
+                    type="button"
+                    class="px-2 py-1 rounded bg-white/10 hover:bg-white/20 text-xs"
+                    (click)="addStringArrayItem(field.key)"
+                  >
+                    Add
+                  </button>
+                </div>
+                <div
+                  class="text-[10px] text-gray-500"
+                  *ngIf="asStringArray(getValue(field.key)).length === 0"
+                >
+                  No values added.
+                </div>
+              </div>
               } @else if (field.type === 'integer') {
               <input
                 type="number"
@@ -132,6 +174,12 @@ export default class SettingsPageComponent implements OnInit {
   asBoolean(v: unknown): boolean {
     return typeof v === 'boolean' ? v : false;
   }
+  asStringArray(v: unknown): string[] {
+    if (Array.isArray(v)) {
+      return v.filter((x) => typeof x === 'string') as string[];
+    }
+    return [];
+  }
 
   getValue(key: string) {
     const curr = this.currentValues();
@@ -151,8 +199,23 @@ export default class SettingsPageComponent implements OnInit {
   onBooleanChange(key: string, value: boolean) {
     this.setValue(key, !!value);
   }
+  onStringArrayItemChange(key: string, index: number, value: string) {
+    const arr = [...this.asStringArray(this.getValue(key))];
+    arr[index] = value;
+    this.setValue(key, arr);
+  }
+  addStringArrayItem(key: string) {
+    const arr = [...this.asStringArray(this.getValue(key))];
+    arr.push('');
+    this.setValue(key, arr);
+  }
+  removeStringArrayItem(key: string, index: number) {
+    const arr = [...this.asStringArray(this.getValue(key))];
+    arr.splice(index, 1);
+    this.setValue(key, arr);
+  }
 
-  setValue(key: string, value: string | number | boolean | null) {
+  setValue(key: string, value: string | number | boolean | null | string[]) {
     this.currentValues.update((curr) => ({ ...curr, [key]: value }));
   }
 
@@ -187,6 +250,8 @@ export default class SettingsPageComponent implements OnInit {
     switch (field.type) {
       case 'string':
         return '';
+      case 'string[]':
+        return [];
       case 'boolean':
         return false;
       case 'integer':
@@ -219,6 +284,10 @@ export default class SettingsPageComponent implements OnInit {
       } else if (field?.type === 'string') {
         // Preserve nulls rather than turning them into the string "null"
         result[key] = value === null ? null : String(value);
+      } else if (field?.type === 'string[]') {
+        result[key] = Array.isArray(value)
+          ? value.filter((v) => typeof v === 'string')
+          : [];
       } else {
         // If schema unknown, attempt best-effort mapping
         if (typeof value === 'string' || typeof value === 'boolean') {
@@ -247,6 +316,12 @@ export default class SettingsPageComponent implements OnInit {
         result[f.key] = Boolean(v);
       } else if (f.type === 'string') {
         result[f.key] = String(v);
+      } else if (f.type === 'string[]') {
+        const arr = Array.isArray(v)
+          ? v.filter((x) => typeof x === 'string' && x.trim().length > 0)
+          : [];
+        // Save as array directly
+        if (arr.length > 0) result[f.key] = arr;
       }
     }
     return result;

--- a/src/chrome-app/src/app/content-pages/settings/settings-page.component.ts
+++ b/src/chrome-app/src/app/content-pages/settings/settings-page.component.ts
@@ -97,12 +97,9 @@ import { settingsSchema } from './settings-schema';
                     Add
                   </button>
                 </div>
-                <div
-                  class="text-[10px] text-gray-500"
-                  *ngIf="asStringArray(getValue(field.key)).length === 0"
-                >
-                  No values added.
-                </div>
+                @if(asStringArray(getValue(field.key)).length === 0) {
+                <div class="text-[10px] text-gray-500">No values added.</div>
+                }
               </div>
               } @else if (field.type === 'integer') {
               <input

--- a/src/chrome-app/src/app/content-pages/settings/settings-schema.ts
+++ b/src/chrome-app/src/app/content-pages/settings/settings-schema.ts
@@ -8,4 +8,12 @@ export const settingsSchema: SettingField[] = [
     description: 'Controls the user agent string sent by the browser.',
     placeholder: '',
   },
+  {
+    key: 'ssoEnabledDomains',
+    type: 'string[]',
+    name: 'SSO Enabled Domains',
+    description:
+      'Domains where Single Sign-On (SSO) is enabled by using a WebView2 based browser. All browser features might not be available. All sub domains are included by default.',
+    placeholder: 'Enter domain name',
+  },
 ];

--- a/src/chrome-app/src/app/content-pages/settings/settingsApi.ts
+++ b/src/chrome-app/src/app/content-pages/settings/settingsApi.ts
@@ -1,10 +1,14 @@
-export type SettingPrimitive = string | number | boolean | null;
+export type SettingPrimitive = string | number | boolean | null | string[];
 
 export type SettingsValues = Record<string, SettingPrimitive>;
 
-export type PlainSettings = Record<string, string | number | boolean>;
+// Plain settings now also allow string[] for array-based values.
+export type PlainSettings = Record<
+  string,
+  string | number | boolean | string[]
+>;
 
-export type SettingType = 'string' | 'boolean' | 'integer';
+export type SettingType = 'string' | 'string[]' | 'boolean' | 'integer';
 
 export interface SettingFieldBase {
   key: string;
@@ -18,6 +22,11 @@ export interface StringField extends SettingFieldBase {
   placeholder?: string;
 }
 
+export interface StringArrayField extends SettingFieldBase {
+  type: 'string[]';
+  placeholder?: string;
+}
+
 export interface BooleanField extends SettingFieldBase {
   type: 'boolean';
 }
@@ -26,7 +35,11 @@ export interface IntegerField extends SettingFieldBase {
   type: 'integer';
 }
 
-export type SettingField = StringField | BooleanField | IntegerField;
+export type SettingField =
+  | StringField
+  | BooleanField
+  | IntegerField
+  | StringArrayField;
 
 export interface SettingsApi {
   settingsPageLoading: () => void;


### PR DESCRIPTION
The aim is to make the fallback browser as seamless as possible, but it can be acceptable to have some slight discrepancies. Since the action dialog and the web view based browser have airspace issues, we solve it by showing an image of the web view browser while the action dialog is visible.

Known issues I have been unable to resolve:
- The image rendered as the action dialog is shown does not seem to render iframes (or at least adds).
- Rounded corners are not anti aliased.
- Only the initially activated tab, when opening the app, gets rounded corners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebView2-backed tabs with automatic backend switching, rounded corners, snapshot preview, unified tab API.
  * In-page search with highlighted matches and next/previous navigation.
  * Settings UI: new "SSO Enabled Domains" editable list; settings now accept/save string-array values.

* **Bug Fixes**
  * Safer null-guards and centralized keyboard handling (F5); more robust devtools, zoom, and navigation behavior.

* **Chores**
  * Added WebView2 runtime dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->