### PR TITLE
Align web content and tab palette with workspace background color

### DIFF
--- a/src/BrowserHost/Features/TabPalette/TabCustomization/TabCustomizationFeature.cs
+++ b/src/BrowserHost/Features/TabPalette/TabCustomization/TabCustomizationFeature.cs
@@ -33,7 +33,10 @@ public class TabCustomizationFeature(MainWindow window) : Feature(window)
 
     public void InitializeCustomSettings()
     {
-        var customization = TabCustomizationStateManager.GetCustomization(Window.CurrentTab!.Id);
+        if (Window.CurrentTab is null)
+            return;
+
+        var customization = TabCustomizationStateManager.GetCustomization(Window.CurrentTab.Id);
         Window.TabPaletteBrowserControl.InitCustomTitle(customization.CustomTitle);
     }
 }

--- a/src/BrowserHost/MainWindow.xaml
+++ b/src/BrowserHost/MainWindow.xaml
@@ -28,7 +28,7 @@
                         <ColumnDefinition Width="300" MinWidth="200" />
                         <ColumnDefinition Width="5" />
                         <ColumnDefinition Width="*" MinWidth="200" />
-                        <ColumnDefinition x:Name="TabPaletteSplitterColumn" Width="5" />
+                        <ColumnDefinition x:Name="TabPaletteSplitterColumn" Width="0" MinWidth="0" />
                         <ColumnDefinition x:Name="TabPaletteColumn" Width="0" MinWidth="0" />
                     </Grid.ColumnDefinitions>
                     <ac:ActionContextBrowser x:Name="ActionContext" Grid.Column="0" />

--- a/src/BrowserHost/MainWindow.xaml
+++ b/src/BrowserHost/MainWindow.xaml
@@ -60,7 +60,16 @@
                         ResizeDirection="Columns"
                         ShowsPreview="False"
                         Visibility="Collapsed"/>
-                    <tp:TabPaletteBrowser x:Name="TabPaletteBrowserControl" Grid.Column="4" Visibility="Collapsed" />
+                    <Border x:Name="TabPaletteBorder" Grid.Column="4" CornerRadius="8" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                        <Border.Clip>
+                            <MultiBinding Converter="{StaticResource BorderClipConverter}">
+                                <Binding Path="ActualWidth" RelativeSource="{RelativeSource Self}"/>
+                                <Binding Path="ActualHeight" RelativeSource="{RelativeSource Self}"/>
+                                <Binding Path="CornerRadius" RelativeSource="{RelativeSource Self}"/>
+                            </MultiBinding>
+                        </Border.Clip>
+                        <tp:TabPaletteBrowser x:Name="TabPaletteBrowserControl" Visibility="Collapsed" />
+                    </Border>
                 </Grid>
                 <ad:ActionDialogBrowser x:Name="ActionDialog" Visibility="Hidden" />
             </Grid>

--- a/src/BrowserHost/MainWindow.xaml
+++ b/src/BrowserHost/MainWindow.xaml
@@ -41,7 +41,7 @@
                         ResizeBehavior="PreviousAndNext"
                         ResizeDirection="Columns"
                         ShowsPreview="False"/>
-                    <Border x:Name="WebContentBorder" Grid.Column="2" CornerRadius="8" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="#202634">
+                    <Border x:Name="WebContentBorder" Grid.Column="2" CornerRadius="8" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                         <Border.Clip>
                             <MultiBinding Converter="{StaticResource BorderClipConverter}">
                                 <Binding Path="ActualWidth" RelativeSource="{RelativeSource Self}"/>
@@ -59,7 +59,6 @@
                         ResizeBehavior="PreviousAndNext"
                         ResizeDirection="Columns"
                         ShowsPreview="False"
-                                  
                         Visibility="Collapsed"/>
                     <tp:TabPaletteBrowser x:Name="TabPaletteBrowserControl" Grid.Column="4" Visibility="Collapsed" />
                 </Grid>

--- a/src/BrowserHost/MainWindow.xaml.cs
+++ b/src/BrowserHost/MainWindow.xaml.cs
@@ -232,6 +232,9 @@ public partial class MainWindow : Window
     {
         if (container.Background is SolidColorBrush contentBrush)
         {
+            if (contentBrush.IsFrozen)
+                contentBrush = contentBrush.Clone();
+
             var animation = new ColorAnimation
             {
                 To = contentColor,

--- a/src/BrowserHost/MainWindow.xaml.cs
+++ b/src/BrowserHost/MainWindow.xaml.cs
@@ -33,6 +33,7 @@ public partial class MainWindow : Window
 {
     private readonly List<Feature> _features;
     private bool _tabPaletteHasBeenShown;
+    private const double _lightenFactor = 0.04;
 
     public ChromiumWebBrowser Chrome => ChromeUI;
     public TabBrowser? CurrentTab => (TabBrowser)WebContentBorder.Child;
@@ -218,14 +219,13 @@ public partial class MainWindow : Window
     private static void OnWorkspaceColorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         var window = (MainWindow)d;
+
         var newColor = (Color)e.NewValue;
+        AnimateBackgroundColor(newColor, window.WindowBorder);
 
-        var mainWindowContainer = window.WindowBorder;
-        AnimateBackgroundColor(newColor, mainWindowContainer);
-
-        var lightenedColor = Lighten(newColor, 0.08);
-        var currentTabContainer = window.WebContentBorder;
-        AnimateBackgroundColor(lightenedColor, currentTabContainer);
+        var lightenedColor = Lighten(newColor, _lightenFactor);
+        AnimateBackgroundColor(lightenedColor, window.WebContentBorder);
+        AnimateBackgroundColor(lightenedColor, window.TabPaletteBorder);
     }
 
     private static void AnimateBackgroundColor(Color contentColor, System.Windows.Controls.Border container)
@@ -262,6 +262,10 @@ public partial class MainWindow : Window
             GridAnimationBehavior.Initialize(TabPaletteSplitterColumn);
             _tabPaletteHasBeenShown = true;
         }
+
+        // Ensure tab palette background matches the current lightened workspace color before showing
+        var lightenedColor = Lighten(WorkspaceColor, _lightenFactor);
+        TabPaletteBorder.Background = new SolidColorBrush(lightenedColor);
 
         TabPaletteBrowserControl.Visibility = Visibility.Visible;
         TabPaletteGridSplitter.Visibility = Visibility.Visible;

--- a/src/BrowserHost/MainWindow.xaml.cs
+++ b/src/BrowserHost/MainWindow.xaml.cs
@@ -257,6 +257,9 @@ public partial class MainWindow : Window
         {
             // We need to initialize the animation because the ActualWidth property does not have a value yet
             GridAnimationBehavior.Initialize(TabPaletteColumn);
+            // Initialize the splitter column to its expanded width (5) so it can animate without popping
+            TabPaletteSplitterColumn.Width = new GridLength(5);
+            GridAnimationBehavior.Initialize(TabPaletteSplitterColumn);
             _tabPaletteHasBeenShown = true;
         }
 
@@ -266,6 +269,9 @@ public partial class MainWindow : Window
         var duration = TimeSpan.FromMilliseconds(300);
         GridAnimationBehavior.SetDuration(TabPaletteColumn, duration);
         GridAnimationBehavior.SetIsExpanded(TabPaletteColumn, true);
+        // Animate the splitter column from 0 -> 5 smoothly
+        GridAnimationBehavior.SetDuration(TabPaletteSplitterColumn, duration);
+        GridAnimationBehavior.SetIsExpanded(TabPaletteSplitterColumn, true);
     }
 
     public void HideTabPalette()
@@ -276,6 +282,9 @@ public partial class MainWindow : Window
         var duration = TimeSpan.FromMilliseconds(200);
         GridAnimationBehavior.SetDuration(TabPaletteColumn, duration);
         GridAnimationBehavior.SetIsExpanded(TabPaletteColumn, false);
+        // Collapse the splitter column from 5 -> 0 smoothly
+        GridAnimationBehavior.SetDuration(TabPaletteSplitterColumn, duration);
+        GridAnimationBehavior.SetIsExpanded(TabPaletteSplitterColumn, false);
         // Hide controls after animation completes
         var timer = new DispatcherTimer { Interval = duration };
         timer.Tick += (s, e) =>

--- a/src/BrowserHost/MainWindow.xaml.cs
+++ b/src/BrowserHost/MainWindow.xaml.cs
@@ -233,7 +233,10 @@ public partial class MainWindow : Window
         if (container.Background is SolidColorBrush contentBrush)
         {
             if (contentBrush.IsFrozen)
+            {
                 contentBrush = contentBrush.Clone();
+                container.Background = contentBrush;
+            }
 
             var animation = new ColorAnimation
             {

--- a/src/chrome-app/src/app/parts/tab-palette/tab-palette.component.ts
+++ b/src/chrome-app/src/app/parts/tab-palette/tab-palette.component.ts
@@ -6,7 +6,7 @@ import { DomainContentComponent } from './domain-content.component';
   selector: 'tab-palette',
   template: `
     <div
-      class="w-full h-full flex-1 min-h-0 bg-gray-800 rounded-lg shadow-lg p-4 flex flex-col gap-6 border border-gray-700"
+      class="w-full h-full flex-1 min-h-0 p-4 flex flex-col gap-6"
       style="position: relative; top: 0; left: 0;right: 0; bottom: 0;"
     >
       <tab-content />


### PR DESCRIPTION
Background colors of all UI elements should be based on the active workspace color.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Smooth animations for showing/hiding the tab palette, including splitter transitions.
  - Background colors now animate and subtly lighten to match the current workspace/theme.
  - Tab palette gains a rounded, clipped container for cleaner presentation.

- Style
  - Flatter, cleaner tab palette (removed heavy borders/shadows and dark background).
  - Splitter hidden by default and main content background simplified.

- Bug Fixes
  - Prevented a rare crash when no active tab is available during customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->