### PR TITLE
Restore original url manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ In browser:
 - **Ctrl-B**: Toggle tab as bookmark.
 - **Ctrl-G**: Toggle whether a bookmarked tab is placed in a folder or not.
 - **Ctrl-P**: Toggle whether the current tab is pinned or not.
+- **Ctrl-R**: Restore a bookmarked or pinned tab to its original address.
 - **Ctrl-MouseWheel**: Change zoom level.
 - **Ctrl-Delete**: Reset zoom level.
 - **Ctrl-1, Ctrl-2, Ctrl-3, etc.**: Switch to workspace 1, 2, 3, etc.

--- a/src/BrowserHost/Features/ActionContext/PinnedTabs/PinnedTabsFeature.cs
+++ b/src/BrowserHost/Features/ActionContext/PinnedTabs/PinnedTabsFeature.cs
@@ -41,8 +41,6 @@ public class PinnedTabsFeature(MainWindow window) : Feature(window)
             NotifyFrontendOfUpdatedPinnedTabs();
             Window.ActionContext.AddTab(new(e.TabId, tab.Title, tab.Favicon, DateTimeOffset.UtcNow)); // We don't currently store creation info for pinned tabs
         });
-        PubSub.Subscribe<TabUrlLoadedSuccessfullyEvent>(e => UpdatePinnedTabState(e.TabId));
-        PubSub.Subscribe<TabFaviconUrlChangedEvent>(e => UpdatePinnedTabState(e.TabId));
         PubSub.Subscribe<TabClosedEvent>(e =>
         {
             RemovePinnedTabFromState(e.Tab.Id);
@@ -92,18 +90,6 @@ public class PinnedTabsFeature(MainWindow window) : Feature(window)
         }
 
         return base.HandleOnPreviewKeyDown(e);
-    }
-
-    private void UpdatePinnedTabState(string tabId)
-    {
-        var updatedTab = Window.GetFeature<TabsFeature>().GetTabBrowserById(tabId);
-        if (!IsTabPinned(tabId))
-            return;
-
-        _pinnedTabData = PinnedTabsStateManager.SavePinnedTabs(_pinnedTabData with
-        {
-            PinnedTabs = [.. _pinnedTabData.PinnedTabs.Where(t => t.Id != tabId), new PinnedTabDtoV1(tabId, updatedTab.Title, updatedTab.Favicon, updatedTab.Address)]
-        });
     }
 
     public PinnedTabDtoV1[] GetPinnedTabs() =>

--- a/src/BrowserHost/Features/ActionContext/PinnedTabs/PinnedTabsFeature.cs
+++ b/src/BrowserHost/Features/ActionContext/PinnedTabs/PinnedTabsFeature.cs
@@ -104,10 +104,13 @@ public class PinnedTabsFeature(MainWindow window) : Feature(window)
         var customizations = TabCustomizationFeature.GetCustomizationsForTab(tabId);
         if (customizations.DisableFixedAddress == true)
         {
-            // By default, the persisted state for pinned tabs is not updated. However, if fixed addresses are disable then we do want to update it.
+            // By default, the persisted state for pinned tabs is not updated. However, if fixed addresses are disabled then we do want to update it.
             _pinnedTabData = PinnedTabsStateManager.SavePinnedTabs(_pinnedTabData with
             {
-                PinnedTabs = [.. _pinnedTabData.PinnedTabs.Where(t => t.Id != tabId), new PinnedTabDtoV1(tabId, updatedTab.Title, updatedTab.Favicon, updatedTab.Address)]
+                PinnedTabs = [.. _pinnedTabData
+                    .PinnedTabs
+                    .Select(t => t.Id == tabId ? new PinnedTabDtoV1(tabId, updatedTab.Title, updatedTab.Favicon, updatedTab.Address) : t)
+                ]
             });
         }
     }

--- a/src/BrowserHost/Features/ActionContext/Tabs/TabsFeature.cs
+++ b/src/BrowserHost/Features/ActionContext/Tabs/TabsFeature.cs
@@ -120,6 +120,8 @@ public class TabsFeature(MainWindow window) : Feature(window)
         if (!string.IsNullOrEmpty(title))
             browser.Title = title;
 
+        browser.SavePersistableState();
+
         PubSub.Publish(new TabBrowserCreatedEvent(browser));
         return browser;
     }
@@ -139,6 +141,7 @@ public class TabsFeature(MainWindow window) : Feature(window)
         if (tab == null || Window.GetFeature<PinnedTabsFeature>().IsTabPinned(tab.Id)) return;
 
         Window.ActionContext.ToggleTabBookmark(tab.Id);
+        tab.SavePersistableState();
     }
 
     public TabBrowser GetTabBrowserById(string tabId) =>

--- a/src/BrowserHost/Features/ActionContext/Workspaces/WorkspacesFeature.cs
+++ b/src/BrowserHost/Features/ActionContext/Workspaces/WorkspacesFeature.cs
@@ -105,7 +105,7 @@ public class WorkspacesFeature(MainWindow window) : Feature(window)
         var browserTab = tabsFeature.GetTabBrowserById(tab.Id);
         return new WorkspaceTabStateDtoV1(
             tab.Id,
-            browserTab?.GetAddresToPersist(isBookmarked, customization) ?? "",
+            browserTab?.GetAddressToPersist(isBookmarked, customization) ?? "",
             browserTab?.GetTitleToPersist(isBookmarked, customization) ?? "",
             browserTab?.GetFaviconToPersist(isBookmarked, customization) ?? "",
             tab.IsActive,

--- a/src/BrowserHost/Features/ActionContext/Workspaces/WorkspacesFeature.cs
+++ b/src/BrowserHost/Features/ActionContext/Workspaces/WorkspacesFeature.cs
@@ -101,12 +101,13 @@ public class WorkspacesFeature(MainWindow window) : Feature(window)
     private WorkspaceTabStateDtoV1 CreateTabState(TabUiStateDto tab, int tabIndex, TabsFeature tabsFeature)
     {
         var customization = TabCustomizationFeature.GetCustomizationsForTab(tab.Id);
-        var isBookmarked = tabIndex < CurrentWorkspace.EphemeralTabStartIndex;
+        var isBookmarked = IsTabBookmarked(tab.Id);
+        var browserTab = tabsFeature.GetTabBrowserById(tab.Id);
         return new WorkspaceTabStateDtoV1(
             tab.Id,
-            tabsFeature.GetTabBrowserById(tab.Id)?.GetAddresToPersist(isBookmarked, customization) ?? "",
-            tabsFeature.GetTabBrowserById(tab.Id)?.GetTitleToPersist(isBookmarked, customization) ?? "",
-            tabsFeature.GetTabBrowserById(tab.Id)?.GetFaviconToPersist(isBookmarked, customization) ?? "",
+            browserTab?.GetAddresToPersist(isBookmarked, customization) ?? "",
+            browserTab?.GetTitleToPersist(isBookmarked, customization) ?? "",
+            browserTab?.GetFaviconToPersist(isBookmarked, customization) ?? "",
             tab.IsActive,
             tab.Created
         );

--- a/src/BrowserHost/Features/TabPalette/TabCustomization/TabCustomizationBrowserApi.cs
+++ b/src/BrowserHost/Features/TabPalette/TabCustomization/TabCustomizationBrowserApi.cs
@@ -4,13 +4,13 @@ using BrowserHost.Utilities;
 namespace BrowserHost.Features.TabPalette.TabCustomization;
 
 public record TabCustomTitleChangedEvent(string TabId, string? CustomTitle);
-public record TabDisableStaticAddressChangedEvent(string TabId, bool DisableStaticAddress);
+public record TabDisableFixedAddressChangedEvent(string TabId, bool IsDisabled);
 
 public class TabCustomizationBrowserApi : BrowserApi
 {
     public void SetCustomTitle(string? newTitle) =>
         PubSub.Publish(new TabCustomTitleChangedEvent(MainWindow.Instance.CurrentTab!.Id, newTitle));
 
-    public void SetDisableStaticAddress(bool disabled) =>
-        PubSub.Publish(new TabDisableStaticAddressChangedEvent(MainWindow.Instance.CurrentTab!.Id, disabled));
+    public void SetDisableFixedAddress(bool disabled) =>
+        PubSub.Publish(new TabDisableFixedAddressChangedEvent(MainWindow.Instance.CurrentTab!.Id, disabled));
 }

--- a/src/BrowserHost/Features/TabPalette/TabCustomization/TabCustomizationBrowserApi.cs
+++ b/src/BrowserHost/Features/TabPalette/TabCustomization/TabCustomizationBrowserApi.cs
@@ -3,10 +3,14 @@ using BrowserHost.Utilities;
 
 namespace BrowserHost.Features.TabPalette.TabCustomization;
 
-public record TabCustomizationChangedEvent(string TabId, string? CustomTitle);
+public record TabCustomTitleChangedEvent(string TabId, string? CustomTitle);
+public record TabDisableStaticAddressChangedEvent(string TabId, bool DisableStaticAddress);
 
 public class TabCustomizationBrowserApi : BrowserApi
 {
     public void SetCustomTitle(string? newTitle) =>
-        PubSub.Publish(new TabCustomizationChangedEvent(MainWindow.Instance.CurrentTab!.Id, newTitle));
+        PubSub.Publish(new TabCustomTitleChangedEvent(MainWindow.Instance.CurrentTab!.Id, newTitle));
+
+    public void SetDisableStaticAddress(bool disabled) =>
+        PubSub.Publish(new TabDisableStaticAddressChangedEvent(MainWindow.Instance.CurrentTab!.Id, disabled));
 }

--- a/src/BrowserHost/Features/TabPalette/TabCustomization/TabCustomizationBrowserApi.cs
+++ b/src/BrowserHost/Features/TabPalette/TabCustomization/TabCustomizationBrowserApi.cs
@@ -8,9 +8,15 @@ public record TabDisableFixedAddressChangedEvent(string TabId, bool IsDisabled);
 
 public class TabCustomizationBrowserApi : BrowserApi
 {
-    public void SetCustomTitle(string? newTitle) =>
-        PubSub.Publish(new TabCustomTitleChangedEvent(MainWindow.Instance.CurrentTab!.Id, newTitle));
+    public void SetCustomTitle(string? newTitle)
+    {
+        if (MainWindow.Instance.CurrentTab is { } tab)
+            PubSub.Publish(new TabCustomTitleChangedEvent(tab.Id, newTitle));
+    }
 
-    public void SetDisableFixedAddress(bool disabled) =>
-        PubSub.Publish(new TabDisableFixedAddressChangedEvent(MainWindow.Instance.CurrentTab!.Id, disabled));
+    public void SetDisableFixedAddress(bool disabled)
+    {
+        if (MainWindow.Instance.CurrentTab is { } tab)
+            PubSub.Publish(new TabDisableFixedAddressChangedEvent(tab.Id, disabled));
+    }
 }

--- a/src/BrowserHost/Features/TabPalette/TabCustomization/TabCustomizationFeature.cs
+++ b/src/BrowserHost/Features/TabPalette/TabCustomization/TabCustomizationFeature.cs
@@ -15,9 +15,9 @@ public class TabCustomizationFeature(MainWindow window) : Feature(window)
             var customization = TabCustomizationStateManager.SaveCustomization(e.TabId, c => c with { CustomTitle = e.CustomTitle });
             Window.ActionContext.UpdateTabCustomization(new(e.TabId, customization?.CustomTitle));
         });
-        PubSub.Subscribe<TabDisableStaticAddressChangedEvent>((e) =>
+        PubSub.Subscribe<TabDisableFixedAddressChangedEvent>((e) =>
         {
-            TabCustomizationStateManager.SaveCustomization(e.TabId, c => c with { DisableFixedAddress = e.DisableStaticAddress });
+            TabCustomizationStateManager.SaveCustomization(e.TabId, c => c with { DisableFixedAddress = e.IsDisabled });
         });
         PubSub.Subscribe<TabClosedEvent>((e) => TabCustomizationStateManager.DeleteCustomization(e.Tab.Id));
         PubSub.Subscribe<EphemeralTabsExpiredEvent>((e) =>

--- a/src/BrowserHost/Features/TabPalette/TabCustomization/TabCustomizationFeature.cs
+++ b/src/BrowserHost/Features/TabPalette/TabCustomization/TabCustomizationFeature.cs
@@ -10,10 +10,14 @@ public class TabCustomizationFeature(MainWindow window) : Feature(window)
     public override void Configure()
     {
         PubSub.Subscribe<TabPaletteRequestedEvent>((_) => InitializeCustomSettings());
-        PubSub.Subscribe<TabCustomizationChangedEvent>((e) =>
+        PubSub.Subscribe<TabCustomTitleChangedEvent>((e) =>
         {
-            var customization = TabCustomizationStateManager.SaveCustomization(new(e.TabId, e.CustomTitle));
+            var customization = TabCustomizationStateManager.SaveCustomization(e.TabId, c => c with { CustomTitle = e.CustomTitle });
             Window.ActionContext.UpdateTabCustomization(new(e.TabId, customization?.CustomTitle));
+        });
+        PubSub.Subscribe<TabDisableStaticAddressChangedEvent>((e) =>
+        {
+            TabCustomizationStateManager.SaveCustomization(e.TabId, c => c with { DisableFixedAddress = e.DisableStaticAddress });
         });
         PubSub.Subscribe<TabClosedEvent>((e) => TabCustomizationStateManager.DeleteCustomization(e.Tab.Id));
         PubSub.Subscribe<EphemeralTabsExpiredEvent>((e) =>
@@ -37,6 +41,6 @@ public class TabCustomizationFeature(MainWindow window) : Feature(window)
             return;
 
         var customization = TabCustomizationStateManager.GetCustomization(Window.CurrentTab.Id);
-        Window.TabPaletteBrowserControl.InitCustomTitle(customization.CustomTitle);
+        Window.TabPaletteBrowserControl.InitCustomSettings(customization);
     }
 }

--- a/src/BrowserHost/Features/TabPalette/TabCustomization/TabCustomizationFeature.cs
+++ b/src/BrowserHost/Features/TabPalette/TabCustomization/TabCustomizationFeature.cs
@@ -43,4 +43,7 @@ public class TabCustomizationFeature(MainWindow window) : Feature(window)
         var customization = TabCustomizationStateManager.GetCustomization(Window.CurrentTab.Id);
         Window.TabPaletteBrowserControl.InitCustomSettings(customization);
     }
+
+    public static TabCustomizationDataV1 GetCustomizationsForTab(string tabId) =>
+        TabCustomizationStateManager.GetCustomization(tabId);
 }

--- a/src/BrowserHost/Features/TabPalette/TabCustomization/TabCustomizationStateManager.cs
+++ b/src/BrowserHost/Features/TabPalette/TabCustomization/TabCustomizationStateManager.cs
@@ -8,7 +8,7 @@ using System.Threading;
 
 namespace BrowserHost.Features.TabPalette.TabCustomization;
 
-public record TabCustomizationDataV1(string TabId, string? CustomTitle);
+public record TabCustomizationDataV1(string TabId, string? CustomTitle, bool? DisableFixedAddress);
 
 public static class TabCustomizationStateManager
 {
@@ -41,7 +41,7 @@ public static class TabCustomizationStateManager
             if (_cachedPerTab.TryGetValue(tabId, out var cached))
                 return cached;
 
-            return new TabCustomizationDataV1(tabId, null);
+            return CreateDefaultCustomization(tabId);
         }
     }
 
@@ -70,7 +70,7 @@ public static class TabCustomizationStateManager
                             if (versioned?.Version == _currentVersion)
                             {
                                 var tabId = Path.GetFileName(dir);
-                                var data = JsonSerializer.Deserialize<PersistentData<TabCustomizationDataV1>>(json)?.Data ?? new(tabId, null);
+                                var data = JsonSerializer.Deserialize<PersistentData<TabCustomizationDataV1>>(json)?.Data ?? CreateDefaultCustomization(tabId);
                                 _cachedPerTab[data.TabId] = data;
                             }
                         }
@@ -91,23 +91,33 @@ public static class TabCustomizationStateManager
         }
     }
 
-    public static TabCustomizationDataV1? SaveCustomization(TabCustomizationDataV1 data)
+    private static TabCustomizationDataV1 CreateDefaultCustomization(string tabId) => new(tabId, null, false);
+
+    public static TabCustomizationDataV1? SaveCustomization(string tabId, Func<TabCustomizationDataV1, TabCustomizationDataV1> updateData)
     {
-        if (data == new TabCustomizationDataV1(data.TabId, null))
-        {
-            // No customization to save
-            DeleteCustomization(data.TabId);
-            return null;
-        }
-
-        var tabId = data.TabId;
-
         lock (_lock)
         {
-            if (_cachedPerTab.TryGetValue(tabId, out var existing) && existing.Equals(data))
+            TabCustomizationDataV1 data;
+            if (_cachedPerTab.TryGetValue(tabId, out var existing))
             {
-                Debug.WriteLine("Skipping tab customization save - no changes detected.");
-                return existing;
+                data = updateData(existing);
+
+                if (existing == data)
+                {
+                    Debug.WriteLine("Skipping tab customization save - no changes detected.");
+                    return existing;
+                }
+            }
+            else
+            {
+                data = updateData(CreateDefaultCustomization(tabId));
+            }
+
+            if (data == CreateDefaultCustomization(tabId))
+            {
+                // No customization to save
+                DeleteCustomization(data.TabId);
+                return null;
             }
 
             var folder = GetTabFolder(tabId);

--- a/src/BrowserHost/Features/TabPalette/TabCustomization/TabCustomizationStateManager.cs
+++ b/src/BrowserHost/Features/TabPalette/TabCustomization/TabCustomizationStateManager.cs
@@ -139,6 +139,7 @@ public static class TabCustomizationStateManager
             catch (Exception e) when (!Debugger.IsAttached)
             {
                 Debug.WriteLine($"Failed to save tab customization for '{tabId}': {e.Message}");
+                return CreateDefaultCustomization(tabId);
             }
 
             return _cachedPerTab[tabId];

--- a/src/BrowserHost/Features/TabPalette/TabCustomization/TabPaletteBrowserExtensions.cs
+++ b/src/BrowserHost/Features/TabPalette/TabCustomization/TabPaletteBrowserExtensions.cs
@@ -4,8 +4,8 @@ namespace BrowserHost.Features.TabPalette.TabCustomization;
 
 public static class TabPaletteBrowserExtensions
 {
-    public static void InitCustomTitle(this TabPaletteBrowser browser, string? title)
+    public static void InitCustomSettings(this TabPaletteBrowser browser, TabCustomizationDataV1 settings)
     {
-        browser.CallClientApi("initCustomTitle", title.ToJsonString());
+        browser.CallClientApi("initCustomSettings", settings.ToJsonObject());
     }
 }

--- a/src/BrowserHost/Tab/TabBrowser.cs
+++ b/src/BrowserHost/Tab/TabBrowser.cs
@@ -1,6 +1,7 @@
 ﻿using BrowserHost.CefInfrastructure;
 using BrowserHost.Features.ActionContext;
 using BrowserHost.Features.Settings;
+using BrowserHost.Features.TabPalette.TabCustomization;
 using BrowserHost.Tab.CefSharp;
 using BrowserHost.Tab.WebView2;
 using System;
@@ -63,14 +64,14 @@ public class TabBrowser : UserControl
         _persistableState = new PersistableState(_browser.Address, _browser.Favicon, _browser.Title);
     }
 
-    public string GetAddresToPersist(bool isBookmarkedOrPinned) =>
-        isBookmarkedOrPinned ? _persistableState?.Address ?? _browser.Address : _browser.Address;
+    public string GetAddresToPersist(bool isBookmarkedOrPinned, TabCustomizationDataV1 tabCustomizations) =>
+        isBookmarkedOrPinned && !tabCustomizations.DisableFixedAddress == true ? _persistableState?.Address ?? _browser.Address : _browser.Address;
 
-    public string GetTitleToPersist(bool isBookmarkedOrPinned) =>
-        isBookmarkedOrPinned ? _persistableState?.Title ?? _browser.Title : _browser.Title;
+    public string GetTitleToPersist(bool isBookmarkedOrPinned, TabCustomizationDataV1 tabCustomizations) =>
+        isBookmarkedOrPinned && !tabCustomizations.DisableFixedAddress == true ? _persistableState?.Title ?? _browser.Title : _browser.Title;
 
-    public string? GetFaviconToPersist(bool isBookmarkedOrPinned) =>
-        isBookmarkedOrPinned ? _persistableState?.Favicon ?? _browser.Favicon : _browser.Favicon;
+    public string? GetFaviconToPersist(bool isBookmarkedOrPinned, TabCustomizationDataV1 tabCustomizations) =>
+        isBookmarkedOrPinned && !tabCustomizations.DisableFixedAddress == true ? _persistableState?.Favicon ?? _browser.Favicon : _browser.Favicon;
 
     private bool ShouldUseWebView2(string address)
     {

--- a/src/BrowserHost/Tab/TabBrowser.cs
+++ b/src/BrowserHost/Tab/TabBrowser.cs
@@ -64,14 +64,14 @@ public class TabBrowser : UserControl
         _persistableState = new PersistableState(_browser.Address, _browser.Favicon, _browser.Title);
     }
 
-    public string GetAddresToPersist(bool isBookmarkedOrPinned, TabCustomizationDataV1 tabCustomizations) =>
-        isBookmarkedOrPinned && !tabCustomizations.DisableFixedAddress == true ? _persistableState?.Address ?? _browser.Address : _browser.Address;
+    public string GetAddressToPersist(bool isBookmarkedOrPinned, TabCustomizationDataV1 tabCustomizations) =>
+        isBookmarkedOrPinned && tabCustomizations.DisableFixedAddress != true ? _persistableState?.Address ?? _browser.Address : _browser.Address;
 
     public string GetTitleToPersist(bool isBookmarkedOrPinned, TabCustomizationDataV1 tabCustomizations) =>
-        isBookmarkedOrPinned && !tabCustomizations.DisableFixedAddress == true ? _persistableState?.Title ?? _browser.Title : _browser.Title;
+        isBookmarkedOrPinned && tabCustomizations.DisableFixedAddress != true ? _persistableState?.Title ?? _browser.Title : _browser.Title;
 
     public string? GetFaviconToPersist(bool isBookmarkedOrPinned, TabCustomizationDataV1 tabCustomizations) =>
-        isBookmarkedOrPinned && !tabCustomizations.DisableFixedAddress == true ? _persistableState?.Favicon ?? _browser.Favicon : _browser.Favicon;
+        isBookmarkedOrPinned && tabCustomizations.DisableFixedAddress != true ? _persistableState?.Favicon ?? _browser.Favicon : _browser.Favicon;
 
     private bool ShouldUseWebView2(string address)
     {

--- a/src/chrome-app/src/app/parts/tab-palette/tab-customization-editor.component.ts
+++ b/src/chrome-app/src/app/parts/tab-palette/tab-customization-editor.component.ts
@@ -68,10 +68,10 @@ import { TabCustomizationApi } from './tabCustomizationApi';
           <input
             type="checkbox"
             class="w-4 h-4 rounded border-white/10 bg-gray-800"
-            [checked]="disableStaticAddress()"
-            (change)="onToggleDisableStatic($any($event.target).checked)"
+            [checked]="disableFixedAddress()"
+            (change)="onToggleDisableFixed($any($event.target).checked)"
           />
-          <span class="text-sm text-gray-300">Disable static address</span>
+          <span class="text-sm text-gray-300">Disable fixed address</span>
         </label>
       </div>
     </div>
@@ -80,7 +80,7 @@ import { TabCustomizationApi } from './tabCustomizationApi';
 export class TabCustomizationEditorComponent implements OnInit {
   title = signal('');
   initialTitle = signal<string | null>(null);
-  disableStaticAddress = signal<boolean>(false);
+  disableFixedAddress = signal<boolean>(false);
 
   titleInput = viewChild.required<ElementRef<HTMLInputElement>>('titleInput');
   private api!: TabCustomizationApi;
@@ -98,7 +98,7 @@ export class TabCustomizationEditorComponent implements OnInit {
         // I'm not sure why this is needed, but there are cases where the title signal does not update the input value.
         this.titleInput().nativeElement.value = settings.customTitle ?? '';
 
-        this.disableStaticAddress.set(settings.disableFixedAddress ?? false);
+        this.disableFixedAddress.set(settings.disableFixedAddress ?? false);
       },
     });
   }
@@ -117,8 +117,8 @@ export class TabCustomizationEditorComponent implements OnInit {
     input.focus();
   }
 
-  async onToggleDisableStatic(checked: boolean) {
-    this.disableStaticAddress.set(!!checked);
-    await this.api.setDisableStaticAddress(!!checked);
+  async onToggleDisableFixed(checked: boolean) {
+    this.disableFixedAddress.set(!!checked);
+    await this.api.setDisableFixedAddress(!!checked);
   }
 }

--- a/src/chrome-app/src/app/parts/tab-palette/tabCustomizationApi.ts
+++ b/src/chrome-app/src/app/parts/tab-palette/tabCustomizationApi.ts
@@ -2,5 +2,5 @@ import { Api } from '../interfaces/api';
 
 export interface TabCustomizationApi extends Api {
   setCustomTitle: (title: string | null) => Promise<void>;
-  setDisableStaticAddress: (disabled: boolean) => Promise<void>;
+  setDisableFixedAddress: (disabled: boolean) => Promise<void>;
 }

--- a/src/chrome-app/src/app/parts/tab-palette/tabCustomizationApi.ts
+++ b/src/chrome-app/src/app/parts/tab-palette/tabCustomizationApi.ts
@@ -2,4 +2,5 @@ import { Api } from '../interfaces/api';
 
 export interface TabCustomizationApi extends Api {
   setCustomTitle: (title: string | null) => Promise<void>;
+  setDisableStaticAddress: (disabled: boolean) => Promise<void>;
 }


### PR DESCRIPTION
Fixes #81 (With the change that you restore the tab address via a keyboard shortcut rather than though the UI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Ctrl+R shortcut to restore a pinned/bookmarked tab’s original address.
  - Per-tab "Disable fixed address" setting (toggle) to opt a tab out of fixed address/title/favicon persistence.
  - Tab state now persists more reliably when tabs are created or when bookmark status changes; persistence respects per‑tab customization.

- Documentation
  - Documented the Ctrl+R shortcut: “Restore a bookmarked or pinned tab to its original address.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->