### PR TITLE
Stop WebView browser from forwarding block text keyboard shortcuts to application 

### DIFF
--- a/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
+++ b/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
@@ -175,7 +175,7 @@ public sealed class WebView2Browser : UserControl, ITabWebBrowser, IDisposable
         }
     }
 
-    private static readonly HashSet<Key> _allowedCtrlEditingKeys = [Key.C, Key.V, Key.X, Key.A, Key.Z, Key.Y];
+    private static readonly HashSet<Key> _allowedCtrlEditingKeys = [Key.C, Key.V, Key.X, Key.A, Key.Z, Key.Y, Key.Delete, Key.Left, Key.Right, Key.Back];
     private void Controller_AcceleratorKeyPressed(object? sender, CoreWebView2AcceleratorKeyPressedEventArgs e)
     {
         if (e.KeyEventKind is not (CoreWebView2KeyEventKind.KeyDown or CoreWebView2KeyEventKind.SystemKeyDown)) return;


### PR DESCRIPTION
This PR stops the webview browser implementation from forwarding key combos such as ctrl-del and ctrl-backspace which are used for text block navigation and manipulation.