### PR TITLE
Handle cases where custom styling would not be applied

### DIFF
--- a/src/BrowserHost/Features/TabPalette/DomainCustomization/DomainCustomizationFeature.cs
+++ b/src/BrowserHost/Features/TabPalette/DomainCustomization/DomainCustomizationFeature.cs
@@ -149,8 +149,7 @@ public class DomainCustomizationFeature(MainWindow window) : Feature(window)
 
                     function applyCss() {{
                         const head = document.head || document.getElementsByTagName('head')[0];
-                        const body = document.body;
-                        if (!head || !body) {{
+                        if (!head) {{
                             if (tries++ < maxTries) {{
                                 setTimeout(applyCss, 100);
                             }}

--- a/src/BrowserHost/Features/TabPalette/DomainCustomization/DomainCustomizationFeature.cs
+++ b/src/BrowserHost/Features/TabPalette/DomainCustomization/DomainCustomizationFeature.cs
@@ -165,9 +165,9 @@ public class DomainCustomizationFeature(MainWindow window) : Feature(window)
                 }})();
             ";
 
-            tab.ExecuteScriptAsync(script);
+            _ = tab.ExecuteScriptAsync(script);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!Debugger.IsAttached)
         {
             Debug.WriteLine($"Failed to inject CSS into tab: {ex.Message}");
         }
@@ -186,7 +186,7 @@ public class DomainCustomizationFeature(MainWindow window) : Feature(window)
                 })();
             ";
 
-            tab.ExecuteScriptAsync(script);
+            _ = tab.ExecuteScriptAsync(script);
         }
         catch (Exception ex)
         {

--- a/src/BrowserHost/Features/TabPalette/DomainCustomization/DomainCustomizationFeature.cs
+++ b/src/BrowserHost/Features/TabPalette/DomainCustomization/DomainCustomizationFeature.cs
@@ -207,7 +207,7 @@ public class DomainCustomizationFeature(MainWindow window) : Feature(window)
 
             _ = tab.ExecuteScriptAsync(script);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!Debugger.IsAttached)
         {
             Debug.WriteLine($"Failed to remove CSS from tab: {ex.Message}");
         }

--- a/src/BrowserHost/Tab/CefSharp/CefSharpTabBrowserAdapter.cs
+++ b/src/BrowserHost/Tab/CefSharp/CefSharpTabBrowserAdapter.cs
@@ -54,49 +54,28 @@ public class CefSharpTabBrowserAdapter(string id, string address, ActionContextB
     public Task CallClientApi(string api, string? arguments = null) { _cefBrowser.CallClientApi(api, arguments); return Task.CompletedTask; }
     public Task ExecuteScriptAsync(string script)
     {
-        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        RunOnUi(() =>
+        if (_cefBrowser.IsDisposed)
+            return Task.CompletedTask;
+
+        if (_cefBrowser.IsBrowserInitialized)
         {
-            if (_cefBrowser.IsDisposed)
+            _cefBrowser.ExecuteScriptAsync(script);
+        }
+        else
+        {
+            void handler(object s, DependencyPropertyChangedEventArgs e)
             {
-                tcs.TrySetException(new ObjectDisposedException(nameof(CefSharpTabBrowser)));
-                return;
+                _cefBrowser.IsBrowserInitializedChanged -= handler;
+                if (_cefBrowser.IsDisposed)
+                    return;
+
+                _cefBrowser.ExecuteScriptAsync(script);
             }
 
-            void Execute()
-            {
-                try
-                {
-                    _cefBrowser.ExecuteScriptAsync(script);
-                    tcs.TrySetResult(true);
-                }
-                catch (Exception ex)
-                {
-                    tcs.TrySetException(ex);
-                }
-            }
+            _cefBrowser.IsBrowserInitializedChanged += handler;
 
-            if (_cefBrowser.IsBrowserInitialized)
-            {
-                _cefBrowser.Dispatcher.BeginInvoke((Action)Execute);
-            }
-            else
-            {
-                DependencyPropertyChangedEventHandler? handler = null;
-                handler = (s, e) =>
-                {
-                    _cefBrowser.IsBrowserInitializedChanged -= handler;
-                    if (_cefBrowser.IsDisposed)
-                    {
-                        tcs.TrySetException(new ObjectDisposedException(nameof(CefSharpTabBrowser)));
-                        return;
-                    }
-                    _cefBrowser.Dispatcher.BeginInvoke((Action)Execute);
-                };
-                _cefBrowser.IsBrowserInitializedChanged += handler;
-            }
-        });
-        return tcs.Task;
+        }
+        return Task.CompletedTask;
     }
     public object? GetBrowserHost() => _cefBrowser.GetBrowserHost();
     public Task<double> GetZoomLevelAsync() => _cefBrowser.GetZoomLevelAsync();


### PR DESCRIPTION
This PR fixes issues where the custom domain styling would not be applied, either because the CefSharp browser was not ready yet or the website was not ready to have css injected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom domain styles now apply consistently, even on slow-loading pages, reducing flicker and missed styling.
  * Reliable removal of styles when disabling or changing settings.

* **Performance & Reliability**
  * Improved handling of tab initialization ensures scripts run at the right time, avoiding errors when tabs are not yet ready or have been closed.
  * More resilient CSS application with retries, leading to smoother tab startup and fewer visual glitches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->