### PR TITLE
Allow users to accept/reject permission requests for the Notifications api

### DIFF
--- a/src/BrowserHost/Features/Notifications/CefSharpPermissionHandler.cs
+++ b/src/BrowserHost/Features/Notifications/CefSharpPermissionHandler.cs
@@ -3,7 +3,7 @@ using System.Windows;
 
 namespace BrowserHost.Features.Notifications;
 
-public class PermissionHandler : CefSharp.Handler.PermissionHandler
+public class CefSharpPermissionHandler : CefSharp.Handler.PermissionHandler
 {
     protected override bool OnShowPermissionPrompt(IWebBrowser chromiumWebBrowser, IBrowser browser, ulong promptId, string requestingOrigin, PermissionRequestType requestedPermissions, IPermissionPromptCallback callback)
     {

--- a/src/BrowserHost/Features/Notifications/CefSharpPermissionHandler.cs
+++ b/src/BrowserHost/Features/Notifications/CefSharpPermissionHandler.cs
@@ -1,4 +1,5 @@
 ﻿using CefSharp;
+using System;
 using System.Windows;
 
 namespace BrowserHost.Features.Notifications;
@@ -24,7 +25,9 @@ public class CefSharpPermissionHandler : CefSharp.Handler.PermissionHandler
     {
         Application.Current.Dispatcher.BeginInvoke(() =>
         {
-            var origin = new System.Uri(requestingOrigin).GetLeftPart(System.UriPartial.Authority);
+            var origin = Uri.TryCreate(requestingOrigin, UriKind.Absolute, out var parsed)
+                    ? parsed.GetLeftPart(UriPartial.Authority)
+                    : requestingOrigin;
             var result = NotificationPermissionDialog.ShowDialog(MainWindow.Instance, origin);
 
             var cefResult = result

--- a/src/BrowserHost/Features/Notifications/NotificationPermissionDialog.cs
+++ b/src/BrowserHost/Features/Notifications/NotificationPermissionDialog.cs
@@ -1,0 +1,192 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace BrowserHost.Features.Notifications;
+
+public class NotificationPermissionDialog : Window
+{
+    public NotificationPermissionDialog(string origin)
+    {
+        Title = "Notification Permission";
+        Width = 450;
+        Height = 200;
+        WindowStyle = WindowStyle.None;
+        ResizeMode = ResizeMode.NoResize;
+        WindowStartupLocation = WindowStartupLocation.CenterOwner;
+        ShowInTaskbar = false;
+        // Make window transparent and draw our own rounded border
+        AllowsTransparency = true;
+        Background = Brushes.Transparent;
+        // Remove window-level border to avoid square outline
+        BorderBrush = null;
+        BorderThickness = new Thickness(0);
+
+        CreateContent(origin);
+    }
+
+    private void CreateContent(string origin)
+    {
+        var mainGrid = new Grid();
+        mainGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+        mainGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+        // Content area
+        var contentPanel = new StackPanel();
+        contentPanel.Margin = new Thickness(20);
+        contentPanel.VerticalAlignment = VerticalAlignment.Center;
+
+        // Icon and text container
+        var headerPanel = new StackPanel();
+        headerPanel.Orientation = Orientation.Horizontal;
+        headerPanel.Margin = new Thickness(0, 0, 0, 15);
+
+        // Notification icon (simple circle)
+        var iconBorder = new Border();
+        iconBorder.Width = 32;
+        iconBorder.Height = 32;
+        iconBorder.CornerRadius = new CornerRadius(16);
+        iconBorder.Background = new SolidColorBrush(Color.FromRgb(0, 120, 215));
+        iconBorder.Margin = new Thickness(0, 0, 15, 0);
+
+        var iconText = new TextBlock();
+        iconText.Text = "🔔";
+        iconText.FontSize = 16;
+        iconText.HorizontalAlignment = HorizontalAlignment.Center;
+        iconText.VerticalAlignment = VerticalAlignment.Center;
+        iconBorder.Child = iconText;
+
+        var titleText = new TextBlock();
+        titleText.Text = "Notification Permission Request";
+        titleText.FontSize = 16;
+        titleText.FontWeight = FontWeights.Bold;
+        titleText.Foreground = Brushes.White;
+        titleText.VerticalAlignment = VerticalAlignment.Center;
+
+        headerPanel.Children.Add(iconBorder);
+        headerPanel.Children.Add(titleText);
+
+        // Message text
+        var messageText = new TextBlock();
+        messageText.Text = $"The website {origin} wants to show notifications.";
+        messageText.FontSize = 14;
+        messageText.Foreground = new SolidColorBrush(Color.FromRgb(200, 200, 200));
+        messageText.TextWrapping = TextWrapping.Wrap;
+        messageText.Margin = new Thickness(0, 0, 0, 10);
+
+        var detailText = new TextBlock();
+        detailText.Text = "You can change this permission later in the tab customization settings.";
+        detailText.FontSize = 12;
+        detailText.Foreground = new SolidColorBrush(Color.FromRgb(160, 160, 160));
+        detailText.TextWrapping = TextWrapping.Wrap;
+
+        contentPanel.Children.Add(headerPanel);
+        contentPanel.Children.Add(messageText);
+        contentPanel.Children.Add(detailText);
+
+        // Button area
+        var buttonPanel = new StackPanel();
+        buttonPanel.Orientation = Orientation.Horizontal;
+        buttonPanel.HorizontalAlignment = HorizontalAlignment.Right;
+        buttonPanel.Margin = new Thickness(20, 0, 20, 20);
+        // Match window background (no darker strip behind buttons)
+        buttonPanel.Background = Brushes.Transparent;
+
+        var denyButton = CreateStyledButton("Deny", false);
+        var allowButton = CreateStyledButton("Allow", true);
+
+        buttonPanel.Children.Add(denyButton);
+        buttonPanel.Children.Add(allowButton);
+
+        Grid.SetRow(contentPanel, 0);
+        Grid.SetRow(buttonPanel, 1);
+
+        mainGrid.Children.Add(contentPanel);
+        mainGrid.Children.Add(buttonPanel);
+
+        // Wrap content in a rounded border to create rounded window corners
+        var rootBorder = new Border
+        {
+            CornerRadius = new CornerRadius(8),
+            Background = new SolidColorBrush(Color.FromRgb(45, 45, 48)),
+            BorderBrush = new SolidColorBrush(Color.FromRgb(70, 70, 74)),
+            BorderThickness = new Thickness(1),
+            SnapsToDevicePixels = true,
+            Child = mainGrid
+        };
+
+        Content = rootBorder;
+
+        // Set focus to deny button by default (safer choice)
+        Loaded += (s, e) => denyButton.Focus();
+    }
+
+    private Button CreateStyledButton(string text, bool isAllow)
+    {
+        var button = new Button();
+        button.Content = text;
+        button.Width = 80;
+        button.Height = 32;
+        button.Margin = new Thickness(10, 0, 0, 0);
+        button.FontSize = 14;
+
+        if (isAllow)
+        {
+            button.Background = new SolidColorBrush(Color.FromRgb(0, 120, 215));
+            button.Foreground = Brushes.White;
+            button.Click += (s, e) => { DialogResult = true; };
+        }
+        else
+        {
+            button.Background = new SolidColorBrush(Color.FromRgb(68, 68, 68));
+            button.Foreground = Brushes.White;
+            button.Click += (s, e) => { DialogResult = false; };
+        }
+
+        button.BorderThickness = new Thickness(0);
+        button.Template = CreateButtonTemplate(isAllow);
+
+        return button;
+    }
+
+    private ControlTemplate CreateButtonTemplate(bool isAllow)
+    {
+        var template = new ControlTemplate(typeof(Button));
+
+        var border = new FrameworkElementFactory(typeof(Border));
+        border.Name = "border";
+        border.SetBinding(Border.BackgroundProperty, new System.Windows.Data.Binding("Background") { RelativeSource = System.Windows.Data.RelativeSource.TemplatedParent });
+        border.SetValue(Border.CornerRadiusProperty, new CornerRadius(3));
+
+        var contentPresenter = new FrameworkElementFactory(typeof(ContentPresenter));
+        contentPresenter.SetValue(ContentPresenter.HorizontalAlignmentProperty, HorizontalAlignment.Center);
+        contentPresenter.SetValue(ContentPresenter.VerticalAlignmentProperty, VerticalAlignment.Center);
+
+        border.AppendChild(contentPresenter);
+        template.VisualTree = border;
+
+        // Add hover effect
+        var hoverTrigger = new Trigger();
+        hoverTrigger.Property = Button.IsMouseOverProperty;
+        hoverTrigger.Value = true;
+
+        var hoverSetter = new Setter();
+        hoverSetter.TargetName = "border";
+        hoverSetter.Property = Border.BackgroundProperty;
+        hoverSetter.Value = isAllow
+            ? new SolidColorBrush(Color.FromRgb(16, 110, 190))
+            : new SolidColorBrush(Color.FromRgb(80, 80, 80));
+
+        hoverTrigger.Setters.Add(hoverSetter);
+        template.Triggers.Add(hoverTrigger);
+
+        return template;
+    }
+
+    public static bool ShowDialog(Window owner, string origin)
+    {
+        var dialog = new NotificationPermissionDialog(origin);
+        dialog.Owner = owner;
+        return dialog.ShowDialog() == true;
+    }
+}

--- a/src/BrowserHost/Features/Notifications/NotificationPermissionDialog.cs
+++ b/src/BrowserHost/Features/Notifications/NotificationPermissionDialog.cs
@@ -128,12 +128,14 @@ public class NotificationPermissionDialog : Window
             button.Background = new SolidColorBrush(Color.FromRgb(0, 120, 215));
             button.Foreground = Brushes.White;
             button.Click += (s, e) => { DialogResult = true; };
+            button.IsDefault = true;
         }
         else
         {
             button.Background = new SolidColorBrush(Color.FromRgb(68, 68, 68));
             button.Foreground = Brushes.White;
             button.Click += (s, e) => { DialogResult = false; };
+            button.IsCancel = true;
         }
 
         button.BorderThickness = new Thickness(0);

--- a/src/BrowserHost/Features/Notifications/NotificationPermissionDialog.cs
+++ b/src/BrowserHost/Features/Notifications/NotificationPermissionDialog.cs
@@ -74,15 +74,8 @@ public class NotificationPermissionDialog : Window
         messageText.TextWrapping = TextWrapping.Wrap;
         messageText.Margin = new Thickness(0, 0, 0, 10);
 
-        var detailText = new TextBlock();
-        detailText.Text = "You can change this permission later in the tab customization settings.";
-        detailText.FontSize = 12;
-        detailText.Foreground = new SolidColorBrush(Color.FromRgb(160, 160, 160));
-        detailText.TextWrapping = TextWrapping.Wrap;
-
         contentPanel.Children.Add(headerPanel);
         contentPanel.Children.Add(messageText);
-        contentPanel.Children.Add(detailText);
 
         // Button area
         var buttonPanel = new StackPanel();

--- a/src/BrowserHost/Features/Notifications/PermissionHandler.cs
+++ b/src/BrowserHost/Features/Notifications/PermissionHandler.cs
@@ -15,17 +15,12 @@ public class PermissionHandler : CefSharp.Handler.PermissionHandler
         return false; // Use default behavior for other permissions
     }
 
-    protected override void OnDismissPermissionPrompt(IWebBrowser chromiumWebBrowser, IBrowser browser, ulong promptId, PermissionRequestResult result)
-    {
-        base.OnDismissPermissionPrompt(chromiumWebBrowser, browser, promptId, result);
-    }
-
     protected override bool OnRequestMediaAccessPermission(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, string requestingOrigin, MediaAccessPermissionType requestedPermissions, IMediaAccessCallback callback)
     {
         return false; // Use default behavior for media permissions
     }
 
-    private bool HandleNotificationPermissionRequest(string requestingOrigin, IPermissionPromptCallback callback)
+    private static bool HandleNotificationPermissionRequest(string requestingOrigin, IPermissionPromptCallback callback)
     {
         Application.Current.Dispatcher.BeginInvoke(() =>
         {

--- a/src/BrowserHost/Features/Notifications/PermissionHandler.cs
+++ b/src/BrowserHost/Features/Notifications/PermissionHandler.cs
@@ -1,0 +1,43 @@
+﻿using CefSharp;
+using System.Windows;
+
+namespace BrowserHost.Features.Notifications;
+
+public class PermissionHandler : CefSharp.Handler.PermissionHandler
+{
+    protected override bool OnShowPermissionPrompt(IWebBrowser chromiumWebBrowser, IBrowser browser, ulong promptId, string requestingOrigin, PermissionRequestType requestedPermissions, IPermissionPromptCallback callback)
+    {
+        if (requestedPermissions.HasFlag(PermissionRequestType.Notifications))
+        {
+            return HandleNotificationPermissionRequest(requestingOrigin, callback);
+        }
+
+        return false; // Use default behavior for other permissions
+    }
+
+    protected override void OnDismissPermissionPrompt(IWebBrowser chromiumWebBrowser, IBrowser browser, ulong promptId, PermissionRequestResult result)
+    {
+        base.OnDismissPermissionPrompt(chromiumWebBrowser, browser, promptId, result);
+    }
+
+    protected override bool OnRequestMediaAccessPermission(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, string requestingOrigin, MediaAccessPermissionType requestedPermissions, IMediaAccessCallback callback)
+    {
+        return false; // Use default behavior for media permissions
+    }
+
+    private bool HandleNotificationPermissionRequest(string requestingOrigin, IPermissionPromptCallback callback)
+    {
+        Application.Current.Dispatcher.BeginInvoke(() =>
+        {
+            var origin = new System.Uri(requestingOrigin).GetLeftPart(System.UriPartial.Authority);
+            var result = NotificationPermissionDialog.ShowDialog(MainWindow.Instance, origin);
+
+            var cefResult = result
+                ? PermissionRequestResult.Accept
+                : PermissionRequestResult.Deny;
+
+            callback.Continue(cefResult);
+        });
+        return true;
+    }
+}

--- a/src/BrowserHost/Features/Notifications/WebViewPermissionHandler.cs
+++ b/src/BrowserHost/Features/Notifications/WebViewPermissionHandler.cs
@@ -4,12 +4,18 @@ using System.Windows;
 
 namespace BrowserHost.Features.Notifications;
 
-public static class WebViewPermissionHandler
+public sealed class WebViewPermissionHandler : IDisposable
 {
-    public static void Register(CoreWebView2 browser)
+    private readonly CoreWebView2 _browser;
+
+    private WebViewPermissionHandler(CoreWebView2 browser)
     {
+        _browser = browser;
         browser.PermissionRequested += Core_PermissionRequested;
     }
+
+    public static WebViewPermissionHandler Register(CoreWebView2 browser) =>
+        new WebViewPermissionHandler(browser);
 
     private static void Core_PermissionRequested(object? sender, CoreWebView2PermissionRequestedEventArgs e)
     {
@@ -34,5 +40,10 @@ public static class WebViewPermissionHandler
                 deferral.Complete();
             }
         });
+    }
+
+    public void Dispose()
+    {
+        _browser.PermissionRequested -= Core_PermissionRequested;
     }
 }

--- a/src/BrowserHost/Features/Notifications/WebViewPermissionHandler.cs
+++ b/src/BrowserHost/Features/Notifications/WebViewPermissionHandler.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Web.WebView2.Core;
+using System;
+using System.Windows;
+
+namespace BrowserHost.Features.Notifications;
+
+public static class WebViewPermissionHandler
+{
+    public static void Register(CoreWebView2 browser)
+    {
+        browser.PermissionRequested += Core_PermissionRequested;
+    }
+
+    private static void Core_PermissionRequested(object? sender, CoreWebView2PermissionRequestedEventArgs e)
+    {
+        if (e.PermissionKind != CoreWebView2PermissionKind.Notifications)
+            return; // let default behavior handle other permissions
+
+        var deferral = e.GetDeferral();
+        Application.Current.Dispatcher.BeginInvoke(() =>
+        {
+            try
+            {
+                var origin = new Uri(e.Uri).GetLeftPart(UriPartial.Authority);
+                var result = NotificationPermissionDialog.ShowDialog(MainWindow.Instance, origin);
+                e.State = result ? CoreWebView2PermissionState.Allow : CoreWebView2PermissionState.Deny;
+            }
+            catch
+            {
+                e.State = CoreWebView2PermissionState.Default;
+            }
+            finally
+            {
+                deferral.Complete();
+            }
+        });
+    }
+}

--- a/src/BrowserHost/Tab/CefSharp/CefSharpTabBrowser.cs
+++ b/src/BrowserHost/Tab/CefSharp/CefSharpTabBrowser.cs
@@ -39,7 +39,7 @@ public class CefSharpTabBrowser : Browser
         DownloadHandler = new DownloadHandler(downloadsPath);
         RequestHandler = new RequestHandler(Id);
         FindHandler = new FindHandler();
-        PermissionHandler = new PermissionHandler();
+        PermissionHandler = new CefSharpPermissionHandler();
 
         BrowserSettings.BackgroundColor = Cef.ColorSetARGB(255, 255, 255, 255);
     }

--- a/src/BrowserHost/Tab/CefSharp/CefSharpTabBrowser.cs
+++ b/src/BrowserHost/Tab/CefSharp/CefSharpTabBrowser.cs
@@ -4,6 +4,7 @@ using BrowserHost.Features.ActionContext.FileDownloads;
 using BrowserHost.Features.ActionContext.Tabs;
 using BrowserHost.Features.CustomWindowChrome;
 using BrowserHost.Features.DragDrop;
+using BrowserHost.Features.Notifications;
 using BrowserHost.Features.TabPalette.FindText;
 using BrowserHost.Utilities;
 using CefSharp;
@@ -38,6 +39,7 @@ public class CefSharpTabBrowser : Browser
         DownloadHandler = new DownloadHandler(downloadsPath);
         RequestHandler = new RequestHandler(Id);
         FindHandler = new FindHandler();
+        PermissionHandler = new PermissionHandler();
 
         BrowserSettings.BackgroundColor = Cef.ColorSetARGB(255, 255, 255, 255);
     }

--- a/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
+++ b/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
@@ -125,7 +125,7 @@ public sealed class WebView2Browser : UserControl, ITabWebBrowser, IDisposable
         _roundedCornerManager.EnsureChildWindowAsync(Dispatcher, () => _controller?.Bounds.Width ?? 0, () => _controller?.Bounds.Height ?? 0);
     }
 
-    private List<IDisposable> _handlers = [];
+    private readonly List<IDisposable> _handlers = [];
     private void WireCoreEvents(ActionContextBrowser actionContextBrowser)
     {
         if (_core == null) return;
@@ -304,6 +304,8 @@ public sealed class WebView2Browser : UserControl, ITabWebBrowser, IDisposable
             if (_core != null)
             {
                 _handlers.ForEach(h => h.Dispose());
+                _handlers.Clear();
+
                 _core.NewWindowRequested -= Core_NewWindowRequested;
                 _core = null;
             }

--- a/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
+++ b/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
@@ -125,6 +125,7 @@ public sealed class WebView2Browser : UserControl, ITabWebBrowser, IDisposable
         _roundedCornerManager.EnsureChildWindowAsync(Dispatcher, () => _controller?.Bounds.Width ?? 0, () => _controller?.Bounds.Height ?? 0);
     }
 
+    private List<IDisposable> _handlers = [];
     private void WireCoreEvents(ActionContextBrowser actionContextBrowser)
     {
         if (_core == null) return;
@@ -151,7 +152,7 @@ public sealed class WebView2Browser : UserControl, ITabWebBrowser, IDisposable
         _core.NewWindowRequested += Core_NewWindowRequested;
         _controller!.AcceleratorKeyPressed += Controller_AcceleratorKeyPressed;
 
-        WebViewPermissionHandler.Register(_core);
+        _handlers.Add(WebViewPermissionHandler.Register(_core));
     }
 
     private void Core_NewWindowRequested(object? sender, CoreWebView2NewWindowRequestedEventArgs e)
@@ -302,8 +303,8 @@ public sealed class WebView2Browser : UserControl, ITabWebBrowser, IDisposable
             PubSub.Unsubscribe<ActionDialogDismissedEvent>(HandleActionDialogDismissedEvent);
             if (_core != null)
             {
+                _handlers.ForEach(h => h.Dispose());
                 _core.NewWindowRequested -= Core_NewWindowRequested;
-                _core.PermissionRequested -= Core_PermissionRequested;
                 _core = null;
             }
             if (_controller != null)


### PR DESCRIPTION
This PR does not cover any mechanisms for seeing what the current setting is, nor for changing the decision after the fact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified, in-app prompt to allow or deny website notifications across embedded browsers (CefSharp & WebView2).
  * Modal dialog shows the requesting site’s origin with clear Allow and Deny actions, centered with sensible focus and hover states.

* **Chores**
  * Permission handlers integrated with browser hosts and tracked for proper disposal so other permission types keep default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->