### PR TITLE
SSO mode for all url changes

### DIFF
--- a/src/BrowserHost/CefInfrastructure/ResourceRequestHandler.cs
+++ b/src/BrowserHost/CefInfrastructure/ResourceRequestHandler.cs
@@ -1,63 +1,17 @@
 ﻿using BrowserHost.Features.ActionContext.Tabs;
-using BrowserHost.Features.Settings;
 using BrowserHost.Utilities;
 using CefSharp;
-using System;
 
 namespace BrowserHost.CefInfrastructure;
 
 public class ResourceRequestHandler(string tabId) : CefSharp.Handler.ResourceRequestHandler
 {
-    private bool _redirectChainActive;
-    private string? _originalUrl;
-    private string? _originalDomain;
-    private bool _ssoFlowPublished;
-
     protected override void OnResourceLoadComplete(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request, IResponse response, UrlRequestStatus status, long receivedContentLength)
     {
         var pageIsSuccessfullyLoaded = frame.IsMain && request.ResourceType == ResourceType.MainFrame && response.StatusCode == 200;
         if (pageIsSuccessfullyLoaded)
             PubSub.Publish(new TabUrlLoadedSuccessfullyEvent(tabId));
 
-        var redirectChainTerminated = frame.IsMain && request.ResourceType == ResourceType.MainFrame && (response.StatusCode < 300 || response.StatusCode >= 400);
-        if (redirectChainTerminated)
-        {
-            _redirectChainActive = false;
-            _originalUrl = null;
-            _originalDomain = null;
-            _ssoFlowPublished = false;
-        }
-
-
         base.OnResourceLoadComplete(chromiumWebBrowser, browser, frame, request, response, status, receivedContentLength);
-    }
-
-    protected override void OnResourceRedirect(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request, IResponse response, ref string newUrl)
-    {
-        if (frame.IsMain && request.ResourceType == ResourceType.MainFrame)
-        {
-            if (!_redirectChainActive)
-            {
-                _redirectChainActive = true;
-                _originalUrl = request.Url;
-                if (Uri.TryCreate(_originalUrl, UriKind.Absolute, out var fromUri))
-                    _originalDomain = fromUri.Host;
-            }
-
-            // Detect SSO flow start when redirecting to login.microsoft.com
-            if (!_ssoFlowPublished)
-            {
-                if (Uri.TryCreate(newUrl, UriKind.Absolute, out var toUri))
-                {
-                    if (string.Equals(toUri.Host, "login.microsoftonline.com", StringComparison.OrdinalIgnoreCase) && _originalDomain != null && _originalUrl != null)
-                    {
-                        _ssoFlowPublished = true;
-                        PubSub.Publish(new SsoFlowStartedEvent(tabId, _originalDomain, _originalUrl));
-                    }
-                }
-            }
-        }
-
-        base.OnResourceRedirect(chromiumWebBrowser, browser, frame, request, response, ref newUrl);
     }
 }

--- a/src/BrowserHost/Tab/TabBrowser.cs
+++ b/src/BrowserHost/Tab/TabBrowser.cs
@@ -117,7 +117,9 @@ public class TabBrowser : UserControl
                 SettingsFeature.ExecutionSettings.AutoAddSsoDomains == true &&
                 IsSsoLoginPage(newAddress) &&
                 e.OldValue is string oldAddress &&
-                Uri.TryCreate(oldAddress, UriKind.Absolute, out var oldUri))
+                Uri.TryCreate(oldAddress, UriKind.Absolute, out var oldUri) &&
+                !string.IsNullOrEmpty(oldUri.Host) &&
+                !ContentServer.IsContentServerUrl(oldAddress))
             {
                 UpgradeToWebView2(oldAddress);
                 PubSub.Publish(new SsoFlowStartedEvent(Id, oldUri.Host, oldAddress));

--- a/src/BrowserHost/Tab/TabBrowser.cs
+++ b/src/BrowserHost/Tab/TabBrowser.cs
@@ -110,15 +110,18 @@ public class TabBrowser : UserControl
         if (_browser is CefSharpTabBrowserAdapter && e.NewValue is string newAddress)
         {
             if (ShouldUseWebView2(newAddress))
+            {
                 UpgradeToWebView2(newAddress);
-
-            if (SettingsFeature.ExecutionSettings.AutoAddSsoDomains == true &&
-                IsSsoLoginPage(newAddress) && e.OldValue is string oldAddress &&
+            }
+            else if (
+                SettingsFeature.ExecutionSettings.AutoAddSsoDomains == true &&
+                IsSsoLoginPage(newAddress) &&
+                e.OldValue is string oldAddress &&
                 Uri.TryCreate(oldAddress, UriKind.Absolute, out var oldUri))
             {
                 UpgradeToWebView2(oldAddress);
                 PubSub.Publish(new SsoFlowStartedEvent(Id, oldUri.Host, oldAddress));
-                return;
+                return; // We restored the old address, so no further processing is needed
             }
         }
 
@@ -133,7 +136,7 @@ public class TabBrowser : UserControl
         }
     }
 
-    private bool IsSsoLoginPage(string address) =>
+    private static bool IsSsoLoginPage(string address) =>
         Uri.TryCreate(address, UriKind.Absolute, out var toUri) &&
         string.Equals(toUri.Host, "login.microsoftonline.com", StringComparison.OrdinalIgnoreCase);
 


### PR DESCRIPTION
This PR changes the previous behaviour that allows you to automatically enable SSO domains to work regardless of which kind of navigation change it is. This is necessary because the navigation change is not a redirect but a JS triggered navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Detects common SSO login pages and streamlines sign-in; surfaces SSO flow events without legacy subscription hooks.
  - Maintains seamless upgrade to WebView2 during eligible navigations.

- Bug Fixes
  - More reliable behavior when addresses change during sign-in flows and redirects.

- Refactor
  - Removed legacy redirect-tracking logic and associated internal state to simplify flow handling.

- Chores
  - Cleaned up unused dependencies to reduce footprint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->