### PR TITLE
Enforce folder closed when not open

### DIFF
--- a/src/chrome-app/src/app/parts/action-context/tab-list-folder.component.ts
+++ b/src/chrome-app/src/app/parts/action-context/tab-list-folder.component.ts
@@ -162,7 +162,6 @@ export class TabsListFolderComponent {
   hasStartedEditingDueToNewState = false;
 
   folderNameInput = viewChild<ElementRef<HTMLInputElement>>('folderNameInput');
-  private contentElement?: HTMLElement;
 
   constructor() {
     effect(() => {


### PR DESCRIPTION
Fixes issue where folders would sometimes appear open in a sort of glitchy way after being dragged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where collapsed folders could appear partially open after reordering or other UI updates.
  - Ensured folder contents consistently remain hidden when collapsed, improving reliability of expand/collapse behavior and visual state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->