### PR TITLE
Reverted support for child tab promotion for WebView browser

### DIFF
--- a/src/BrowserHost/Features/ActionContext/Tabs/ChildBrowserWindow.cs
+++ b/src/BrowserHost/Features/ActionContext/Tabs/ChildBrowserWindow.cs
@@ -131,15 +131,25 @@ public class ChildBrowserWindow : OverlayWindow
         convertBtn.Margin = new Thickness(0, 8, 0, 0); // gap between buttons
         convertBtn.Click += (_, __) =>
         {
-            PrepareBrowserForPromotion();
             var address = _browser.Address;
-            // Trigger regular navigation (new tab)
-            contentGrid.Children.Remove(_browser);
-            _browser.PromoteToFullTab();
-            PubSub.Publish(new NavigationStartedEvent(address, UseCurrentTab: false, SaveInHistory: true, ActivateTab: true, ReuseTabBrowser: _browser));
-            // Close this child window
-            BeginCloseWithFade();
-            AnimateContentOut(animateBrowser: false);
+
+            if (_browser.SupportsPromotionToFullTab)
+            {
+                PrepareBrowserForPromotion();
+                // Trigger regular navigation (new tab)
+                contentGrid.Children.Remove(_browser);
+                _browser.PromoteToFullTab();
+                PubSub.Publish(new NavigationStartedEvent(address, UseCurrentTab: false, SaveInHistory: true, ActivateTab: true, ReuseTabBrowser: _browser));
+                // Close this child window
+                BeginCloseWithFade();
+                AnimateContentOut(animateBrowser: false);
+            }
+            else
+            {
+                PubSub.Publish(new NavigationStartedEvent(address, UseCurrentTab: false, SaveInHistory: true, ActivateTab: true));
+                BeginCloseWithFade();
+                AnimateContentOut();
+            }
         };
 
         _buttonsPanel.Children.Add(closeBtn);

--- a/src/BrowserHost/Tab/CefSharp/CefSharpTabBrowserAdapter.cs
+++ b/src/BrowserHost/Tab/CefSharp/CefSharpTabBrowserAdapter.cs
@@ -38,6 +38,9 @@ public class CefSharpTabBrowserAdapter : ITabWebBrowser
     public double DefaultZoomLevel => 0.0;
 
     public bool HasDevTools => RunOnUi(() => _cefBrowser.GetBrowserHost().HasDevTools);
+
+    public bool SupportsPromotionToFullTab => true;
+
     public event EventHandler? PageLoadEnded;
 
     public event DependencyPropertyChangedEventHandler? AddressChanged

--- a/src/BrowserHost/Tab/ITabWebBrowser.cs
+++ b/src/BrowserHost/Tab/ITabWebBrowser.cs
@@ -17,6 +17,7 @@ public interface ITabWebBrowser : IDisposable
     bool CanGoForward { get; }
     bool HasDevTools { get; }
     double DefaultZoomLevel { get; }
+    bool SupportsPromotionToFullTab { get; }
 
     event DependencyPropertyChangedEventHandler? AddressChanged;
 

--- a/src/BrowserHost/Tab/TabBrowser.cs
+++ b/src/BrowserHost/Tab/TabBrowser.cs
@@ -45,6 +45,7 @@ public class TabBrowser : UserControl
     public bool CanGoBack => _browser.CanGoBack;
     public bool CanGoForward => _browser.CanGoForward;
     public bool HasDevTools => _browser.HasDevTools;
+    public bool SupportsPromotionToFullTab => _isChildBrowser && _browser.SupportsPromotionToFullTab;
 
     public TabBrowser(string id, string address, ActionContextBrowser actionContextBrowser, bool setManualAddress, string? favicon, bool isChildBrowser)
     {

--- a/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
+++ b/src/BrowserHost/Tab/WebView2/WebView2Browser.cs
@@ -91,6 +91,7 @@ public sealed class WebView2Browser : UserControl, ITabWebBrowser, IDisposable
     public bool CanGoForward => RunOnUi(() => _core?.CanGoForward ?? false);
     public bool HasDevTools => false;
     public double DefaultZoomLevel => 1.0;
+    public bool SupportsPromotionToFullTab => false;
 
     private void HandleActionDialogShownEvent(ActionDialogShownEvent _)
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved convert button robustness with intelligent browser capability detection. The button now automatically determines whether a browser supports full-tab promotion and selects the appropriate conversion method accordingly, using standard navigation as a graceful fallback for browsers that don't support this capability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->